### PR TITLE
Fix live Changes updates after code selection

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -176,11 +176,16 @@ rows select their original line; side-by-side drags stay on the starting side.
 Scroll the code pane with the wheel to reach more lines while selecting, or
 Shift-click to extend a selection if your terminal forwards Shift-click. Release
 outside the pane ends the drag without activating another control. **V** clears
-the selection.
+the selection and resumes live updates. Leaving the selection to browse files or
+switch between Changes and Full file also resumes updates. A version explicitly
+pinned with **P** stays pinned until you choose **Resume live**.
 
 While selecting, the pane shows the selected range and bottom controls for
 **Add to agent**, **Copy**, **Clear**, and **Resume live**. Adding to the agent
 prepares a draft; you still type your question and send it in the native CLI.
+Submitting that draft with Enter releases the selection's temporary pin, so
+the agent's next edits appear automatically. Until then, you can return to the
+same selection and add more code to the draft.
 
 Keyboard selection still works: move to the first source line, press **V**, then
 use arrows to extend the range. You can also paste the current source line

--- a/internal/app/agent_paste_test.go
+++ b/internal/app/agent_paste_test.go
@@ -123,6 +123,33 @@ func TestPasteUnavailableDoesNotWriteToChild(t *testing.T) {
 	}
 }
 
+func TestSubmittingAgentDraftResumesSelectionUpdates(t *testing.T) {
+	for _, explicitPin := range []bool{false, true} {
+		var input bytes.Buffer
+		s := pasteState(&input)
+		if explicitPin {
+			s.review.Key("P", 10)
+		}
+		s.review.SelectWithMouse(2, 0, false)
+		old := s.review.Snapshot.Tree
+		latest := s.review.Snapshot
+		latest.Tree = strings.Repeat("b", 40)
+		s.review.Update(latest)
+		s.finishAgentPaste(nil)
+		s.handleInput([]byte("Explain this\r"), &input)
+		if s.review.Selecting || s.review.AgentDraft || s.review.Pinned != explicitPin {
+			t.Fatalf("explicitPin=%t: draft submission did not release only the selection pin", explicitPin)
+		}
+		want := latest.Tree
+		if explicitPin {
+			want = old
+		}
+		if s.review.Snapshot.Tree != want {
+			t.Fatal("draft submission displayed the wrong version")
+		}
+	}
+}
+
 type failedPaste struct{}
 
 func (failedPaste) Write(p []byte) (int, error) { return len(p) / 2, errors.New("closed PTY") }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -494,6 +494,9 @@ func (s *screenState) handleInput(data []byte, child io.Writer) {
 		}
 		if !s.diffFocused {
 			if b == '\r' || b == '\n' {
+				if s.review.AgentDraft {
+					s.review.ClearSelection()
+				}
 				s.review.AgentDraft = false
 			}
 			_, _ = child.Write([]byte{b})

--- a/internal/app/live_changes_test.go
+++ b/internal/app/live_changes_test.go
@@ -1,0 +1,75 @@
+package app
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nccapo/stvena/internal/diffview"
+	"github.com/nccapo/stvena/internal/session"
+)
+
+func TestChangesRefreshFromExternalProcess(t *testing.T) {
+	root, _ := workflowProject(t)
+	saved, err := session.Open(root, true, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer saved.Close()
+	events, stop, done := make(chan any, 1), make(chan struct{}), make(chan struct{})
+	go func() {
+		defer close(done)
+		watchSnapshots(root, nil, saved, events, stop)
+	}()
+	defer func() { close(stop); <-done }()
+	s := screenState{root: root, session: saved}
+	s.review.Source = "session"
+	await := func(matches func(diffEvent) bool) diffEvent {
+		t.Helper()
+		timer := time.NewTimer(10 * time.Second)
+		defer timer.Stop()
+		for {
+			select {
+			case event := <-events:
+				value := event.(diffEvent)
+				s.sessionView = value.session
+				s.updateSource()
+				if value.session.Err != nil {
+					t.Fatal(value.session.Err)
+				}
+				if matches(value) {
+					return value
+				}
+			case <-timer.C:
+				t.Fatalf("external edits did not reach Changes: %+v", s.review.Snapshot)
+			}
+		}
+	}
+	await(func(e diffEvent) bool { return e.session.Tree != "" })
+	for _, script := range []string{
+		"printf 'package main\nfunc changed() {}\n' > a.go; printf 'new file\n' > new.txt; rm b.go",
+		"printf 'package main\nfunc updated() {}\n' > a.go; mv new.txt renamed.txt",
+	} {
+		cmd := exec.Command("sh", "-c", script)
+		cmd.Dir = root
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("external writer: %s %v", out, err)
+		}
+		want, added := "+func changed() {}", "new.txt"
+		if strings.Contains(script, "updated") {
+			want, added = "+func updated() {}", "renamed.txt"
+		}
+		e := await(func(e diffEvent) bool {
+			found := map[string]diffview.File{}
+			for _, f := range s.review.Snapshot.Files {
+				found[f.Path] = f
+			}
+			return strings.Contains(strings.Join(found["a.go"].Lines, "\n"), want) &&
+				found["b.go"].Status == "D" && found[added].Status == "A" && e.snapshot.Err == nil
+		})
+		if e.project.Tree != e.session.Tree || e.snapshot.Tree != e.session.Tree {
+			t.Fatal("views did not refresh to the same captured files")
+		}
+	}
+}

--- a/internal/app/workspace.go
+++ b/internal/app/workspace.go
@@ -217,6 +217,7 @@ func (s *screenState) dispatch(ctx context.Context, events chan<- any, stop <-ch
 		snapshot.Finish()
 		latest := s.review.Latest
 		s.review.Pinned = false
+		s.review.ClearSelection()
 		s.review.Scope = 0
 		s.review.Update(snapshot)
 		s.review.Latest = latest

--- a/internal/review/actions.go
+++ b/internal/review/actions.go
@@ -232,10 +232,13 @@ func (s *State) AdvancedKey(key string, visible int) bool {
 		}
 		if s.Selecting {
 			s.ClearSelection()
+			s.Notice = ""
+			return true
 		} else {
 			s.Selecting = true
 			if !s.Pinned {
 				s.Pinned = true
+				s.selectionPinned = true
 				s.PinnedVersion = s.Snapshot.Version
 				s.Latest = s.Snapshot
 			}
@@ -298,6 +301,7 @@ func (s *State) AdvancedKey(key string, visible int) bool {
 		}
 		if s.Pinned {
 			s.Pinned = false
+			s.ClearSelection()
 			s.Update(s.Latest)
 			s.Notice = "Live updates resumed"
 		} else {
@@ -513,7 +517,15 @@ func (s *State) MoveLine(delta int) {
 	}
 }
 
-func (s *State) ClearSelection() { s.Selecting = false; s.SelectionMouse = false; s.SelectionSide = 0 }
+func (s *State) ClearSelection() {
+	s.Selecting, s.SelectionMouse, s.SelectionSide = false, false, 0
+	resume := s.selectionPinned && s.Pinned
+	s.selectionPinned = false
+	if resume {
+		s.Pinned = false
+		s.Update(s.Latest)
+	}
+}
 func (s *State) SelectionIncludes(index int, line NumberedLine) bool {
 	a, b := s.Scroll, s.Scroll
 	if s.SelectionMouse {
@@ -543,6 +555,7 @@ func (s *State) SelectWithMouse(index int, side byte, extend bool) {
 	s.Browser = false
 	if !s.Pinned {
 		s.Pinned = true
+		s.selectionPinned = true
 		s.PinnedVersion = s.Snapshot.Version
 		s.Latest = s.Snapshot
 	}

--- a/internal/review/live_test.go
+++ b/internal/review/live_test.go
@@ -1,0 +1,41 @@
+package review
+
+import (
+	"testing"
+
+	"github.com/nccapo/stvena/internal/diffview"
+)
+
+func TestClearingSelectionResumesLiveChanges(t *testing.T) {
+	for _, mouse := range []bool{false, true} {
+		for _, key := range []string{"V", "P", "f", "esc", "backspace", "v", "view-diff"} {
+			s := State{PatchFocused: true, FullFile: true}
+			s.Update(diffview.Snapshot{Tree: "old", Files: []diffview.File{{Path: "file.go"}}})
+			if mouse {
+				s.SelectWithMouse(0, 0, false)
+			} else {
+				s.Key("V", 10)
+			}
+			s.Update(diffview.Snapshot{Tree: "new", Files: []diffview.File{{Path: "file.go"}, {Path: "added.go"}}})
+			if !s.Pinned || s.Snapshot.Tree != "old" {
+				t.Fatal("selection did not retain its captured code")
+			}
+			s.Key(key, 10)
+			if s.Pinned || s.Selecting || s.Snapshot.Tree != "new" || len(s.Indices) != 2 {
+				t.Errorf("mouse=%t key=%s: clearing selection left Changes frozen: pinned=%t selecting=%t tree=%s", mouse, key, s.Pinned, s.Selecting, s.Snapshot.Tree)
+			}
+		}
+	}
+}
+
+func TestClearingSelectionPreservesExplicitPin(t *testing.T) {
+	s := State{PatchFocused: true}
+	s.Update(diffview.Snapshot{Tree: "old", Files: []diffview.File{{Path: "file.go"}}})
+	s.Key("P", 10)
+	s.SelectWithMouse(0, 0, false)
+	s.Update(diffview.Snapshot{Tree: "new"})
+	s.Key("V", 10)
+	if !s.Pinned || s.Snapshot.Tree != "old" || s.Selecting {
+		t.Fatal("clearing selection released an explicit pin")
+	}
+}

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -30,6 +30,7 @@ type State struct {
 	Latest                            diffview.Snapshot
 	Pinned, SideBySide, Wrap          bool
 	PinnedVersion                     string
+	selectionPinned                   bool
 	Menu                              bool
 	MenuIndex                         int
 	Prompt, Input, Notice, Request    string
@@ -183,12 +184,18 @@ func (s *State) Clamp(visible int) {
 
 // Key accepts a decoded key or a Unicode character; no keys mutate Git/files.
 func (s *State) Key(key string, visible int) {
+	if s.Selecting && !s.Menu && s.Prompt == "" && s.Panel == "" && !s.Help && !s.Searching {
+		switch key {
+		case "f", "esc", "backspace", "n", "p", "v", "s", "view-file", "view-diff":
+			s.ClearSelection()
+		}
+	}
 	if s.SelectionMouse && !s.Menu && s.Prompt == "" && s.Panel == "" && !s.Help && !s.Searching {
 		switch key {
 		case "up", "down", "j", "k", "pageup", "pagedown", "d", "u", "g", "G", "home", "end", "[", "]":
 			s.Scroll = s.SelectionEnd
 			s.ClearSelection()
-		case "v", "s", "w", "f", "backspace", "n", "p", "tab", "1", "2", "P", "R", "esc", ":", "/":
+		case "v", "s", "w", "f", "backspace", "n", "p", "tab", "1", "2", "R", "esc", ":", "/":
 			s.ClearSelection()
 		}
 	}

--- a/internal/ui/review_controls.go
+++ b/internal/ui/review_controls.go
@@ -10,6 +10,14 @@ import (
 type reviewControl struct{ key, label string }
 
 func reviewControls(s *review.State) []reviewControl {
+	controls := baseReviewControls(s)
+	if s.Pinned && !s.Selecting {
+		controls = append([]reviewControl{{"P", "P: Resume live"}}, controls...)
+	}
+	return controls
+}
+
+func baseReviewControls(s *review.State) []reviewControl {
 	if s.Source == "project" && s.Browser {
 		label := "Enter: Open"
 		if s.ProjectFolderSelected() {

--- a/internal/ui/review_controls_test.go
+++ b/internal/ui/review_controls_test.go
@@ -47,3 +47,14 @@ func TestReviewControlsMatchVisibleLabelsAndYieldToErrors(t *testing.T) {
 		t.Fatal("selection hid the snapshot error")
 	}
 }
+
+func TestPinnedViewOffersResumeWithoutSelection(t *testing.T) {
+	for _, browser := range []bool{false, true} {
+		s := review.State{Pinned: true, Browser: browser}
+		s.Snapshot = diffview.Snapshot{Tree: "captured"}
+		rows := renderReview(&s, 35, 20, true)
+		if !strings.Contains(ansi.Strip(rows[19]), "P: Resume live") || ReviewControlKeyAt(&s, 35, 20, 4, 19) != "P" {
+			t.Fatalf("browser=%t: pinned view has no visible resume control", browser)
+		}
+	}
+}


### PR DESCRIPTION
Selecting code could leave the Changes view frozen after the selection was cleared or a pasted agent request was submitted. Temporary selection pins now release when the selection ends or the pasted request is submitted, allowing subsequent agent edits to appear automatically. Explicit pins remain in place and show a visible Resume live control.

Adds regression coverage for mouse and keyboard selection, agent draft submission, explicit pins, and external-process file edits, additions, renames, and deletions through the snapshot refresh loop. Updates the usage documentation.

Validation: `go test -race ./...`, `go vet ./...`, `go build -o bin/stvena ./cmd/stvena`, and formatting/diff checks passed locally.
