### PR TITLE
feat: add review checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Stvena
 
-**Your coding agent. Your changes. One terminal.**
+**Stop reopening your IDE just to review what your coding agent changed.**
+
+Run Codex or Claude Code beside a live review workspace in the same terminal.
+Inspect every changed file, read the surrounding code, run checks, select exact
+lines, and send that context straight back to the agent.
 
 <!-- demo:start -->
 https://github.com/user-attachments/assets/7aecafe5-1e45-442e-ab49-82cfc3750d9f
@@ -10,12 +14,11 @@ https://github.com/user-attachments/assets/7aecafe5-1e45-442e-ab49-82cfc3750d9f
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/nccapo/stvena)](https://github.com/nccapo/stvena/releases/latest)
 
-Stvena runs your coding agent beside a live code review workspace. Keep the
-agent's native terminal experience while you inspect changes, read complete
-files, collect context, and run checks against the code you are reviewing.
-
 Built in Go. Designed for terminal workflows with Codex and Claude Code.
 **Early-stage software:** interfaces and local storage formats may change.
+
+If Stvena saves you from the "open the IDE just for the diff" loop, consider
+[starring the repository](https://github.com/nccapo/stvena).
 
 ## Why Stvena?
 
@@ -123,6 +126,7 @@ but direct selection paste is supported for Codex and Claude Code.
 | **Drag / V** | Select code with mouse / keyboard |
 | **b / x / B** | Paste selection / collect selection / open context |
 | **P** | Pin the displayed version or resume live updates |
+| **K / Z** | Start Review checkpoint / finish and preview its draft |
 | **Space / N** | Mark file reviewed / next unreviewed file |
 | **t / T** | Run a check / inspect results |
 | **a / ?** | Actions menu / keyboard help |
@@ -131,6 +135,15 @@ Review shortcuts apply when review has focus. **Ctrl-C** keeps the agent's
 native interrupt behavior. Review remains open after the agent exits; **q**
 closes it. See the [complete user guide](docs/usage.md) for comments, hunk staging,
 search, clipboard tools, and every shortcut.
+
+For a review pause, switch panes with **Ctrl-G**, then choose **Actions → Review
+checkpoint** (**K**) after the agent changes files. Stvena pins the captured
+session tree. Use **Space/H** to review files/hunks, **N** for the next unreviewed
+file, and **c** or **x** to save exact-line comments or selections across files.
+**Finish checkpoint** (**Z**) warns about remaining work and previews one draft;
+**b** pastes it into Codex/Claude Code without submitting, or copies it in
+standalone review. **P** resumes live; changed items need review again. An open
+checkpoint and its feedback survive reopening a saved review.
 
 ## Privacy and local data
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -134,6 +134,27 @@ The code viewer provides:
 
 ## Review an evolving change
 
+After the agent edits `api.go` and `api_test.go`, press **Ctrl-G**, then choose
+**Actions → Review checkpoint** (**K**). The current captured session tree stays
+pinned while you use **Space** / **H** to mark files / hunks and **N** to find the
+next unreviewed file. Select an exact range in each file, use **c** to comment or
+**x** to collect code, and optionally add your request in **B**, then **i**.
+The header counts reviewed files/hunks, saved comments and tray selections;
+**NEW LIVE** means a newer capture exists and has not been reviewed.
+Choose **Finish checkpoint** (**Z**) to preview the combined draft. If review is
+incomplete, **Esc** returns to review; **Enter** previews anyway. In the preview,
+**b** prepares one Codex/Claude Code input without pressing Enter; standalone
+review copies it instead, and **y** always copies. Return with **Esc**, then
+**P** to resume live and review changed items again. Closing and reopening a
+saved review preserves the pinned checkpoint, marks, feedback and draft.
+
+Checkpoint drafts include comments anchored to that checkpoint tree and all
+items currently in the existing context tray, including their original paths,
+line ranges, code and versions. Remove unwanted tray items with **B**, then
+**d** before finishing. Source switching, history comparisons and tested-source
+navigation require resuming live first, so they cannot replace checkpoint code.
+The assembled draft has the same 32 KiB limit as context handoffs.
+
 **P** pins the displayed version while the agent keeps running. An update badge
 shows when newer changes arrive; P resumes live updates. Full-file content stays
 on the pinned version too.
@@ -270,6 +291,7 @@ There are no discard, restore, commit, push or branch-editing actions.
 | [ / ] | Previous / next hunk or full-file change |
 | h/l, ←/→ / 0 | Horizontal scroll / reset horizontal offset |
 | P / R | Pin or resume live / compare since review |
+| K / Z | Start Review checkpoint / finish and preview the assembled draft |
 | Space / H | Mark file / hunk reviewed |
 | b | Paste selected code, or the assembled draft while in Context |
 | x / B | Collect selected code / open the saved context tray |
@@ -285,7 +307,7 @@ unchanged except for the reserved Ctrl-G focus and Ctrl-Q quit keys.
 
 ## Local storage and limits
 
-Session metadata, comments, review marks, context attachments, draft requests,
+Session metadata, pinned checkpoints, comments, review marks, context attachments, draft requests,
 preferences and the latest check result
 are stored under the OS user cache directory in `stvena/<repository hash>`.
 Private `refs/stvena/sessions/*` and `refs/stvena/reviews/*` retain Git objects

--- a/internal/app/agent_paste.go
+++ b/internal/app/agent_paste.go
@@ -46,6 +46,12 @@ func (s *screenState) pasteToAgent(events chan<- any, stop <-chan struct{}) {
 	if s.review.Panel == "Context" || s.review.Panel == "Context preview" {
 		message, err = s.review.ContextMessage()
 	}
+	if s.review.Panel == "Checkpoint draft" && s.review.Checkpoint != nil {
+		message, err = s.review.Checkpoint.Draft, nil
+		if message == "" {
+			err = fmt.Errorf("Finish the checkpoint to prepare its draft first")
+		}
+	}
 	if err != nil {
 		s.review.Notice = err.Error()
 		return
@@ -84,4 +90,10 @@ func (s *screenState) finishAgentPaste(err error) {
 	s.fullscreen = false
 	s.relayout(s.layout.Width, s.layout.Height)
 	s.review.Notice = "Code pasted · add your request in the agent, then press Enter"
+	if s.review.Panel == "Checkpoint draft" && s.review.Checkpoint != nil {
+		s.review.Notice = "Checkpoint draft pasted · inspect and submit in the agent · P: resume live"
+		if err := s.review.Save(); err != nil {
+			s.review.Notice = "Save checkpoint: " + err.Error()
+		}
+	}
 }

--- a/internal/app/agent_paste_test.go
+++ b/internal/app/agent_paste_test.go
@@ -164,3 +164,59 @@ func TestPasteFailureKeepsSelectionAndDoesNotRetry(t *testing.T) {
 		t.Fatal("partial paste was hidden or retried")
 	}
 }
+
+type countedInput struct {
+	bytes.Buffer
+	writes int
+}
+
+func (w *countedInput) Write(p []byte) (int, error) {
+	w.writes++
+	return w.Buffer.Write(p)
+}
+
+func TestLargeTerminalPasteIsLiteralAndDeliveredOnce(t *testing.T) {
+	message := strings.Repeat("Explain this code: 目录\n\r\x07\x11\x1b[A\x1b[20x\n", 2048)
+	payload := ansi.BracketedPasteStart + message + ansi.BracketedPasteEnd
+	for _, chunkSize := range []int{1, 5, 256, 4096, len(payload)} {
+		t.Run(strconv.Itoa(chunkSize), func(t *testing.T) {
+			s := screenState{layout: ui.NewLayout(140, 40)}
+			s.review.AgentDraft = true
+			var child countedInput
+			chunks := 0
+			for offset := 0; offset < len(payload); offset += chunkSize {
+				s.handleInput([]byte(payload[offset:min(offset+chunkSize, len(payload))]), &child)
+				chunks++
+			}
+			if child.String() != payload {
+				t.Fatalf("paste changed: received %d bytes, want %d", child.Len(), len(payload))
+			}
+			if s.diffFocused || s.review.Request != "" || !s.review.AgentDraft {
+				t.Fatal("paste triggered a shortcut or submitted the agent draft")
+			}
+			if child.writes > chunks {
+				t.Fatalf("paste fragmented into %d writes for %d input chunks", child.writes, chunks)
+			}
+			s.handleInput([]byte("follow-up\r\x07"), &child)
+			if child.String() != payload+"follow-up\r" || !s.diffFocused || s.review.AgentDraft {
+				t.Fatal("normal input did not resume after paste")
+			}
+		})
+	}
+}
+
+func TestTerminalPasteInReviewDoesNotRunShortcuts(t *testing.T) {
+	s := pasteState(&bytes.Buffer{})
+	var child bytes.Buffer
+	payload := ansi.BracketedPasteStart + "bq\x07\x11\r" + ansi.BracketedPasteEnd
+	for _, b := range []byte(payload) {
+		s.handleInput([]byte{b}, &child)
+	}
+	if child.Len() != 0 || s.review.Request != "" || !s.diffFocused {
+		t.Fatal("review paste ran a shortcut or leaked to the agent")
+	}
+	s.handleInput([]byte{0x11}, &child)
+	if s.review.Request != "quit-app" {
+		t.Fatal("Ctrl-Q stopped working after paste")
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -171,7 +171,7 @@ func Run(args []string) error {
 		return fmt.Errorf("enable raw terminal: %w", err)
 	}
 	defer func() {
-		_, _ = io.WriteString(os.Stdout, "\x1b[?1000l\x1b[?1002l\x1b[?1006l\x1b[0m\x1b[?25h\x1b[?1049l")
+		_, _ = io.WriteString(os.Stdout, ansi.ResetModeBracketedPaste+"\x1b[?1000l\x1b[?1002l\x1b[?1006l\x1b[0m\x1b[?25h\x1b[?1049l")
 		_ = term.Restore(int(os.Stdin.Fd()), oldState)
 	}()
 	_, _ = io.WriteString(os.Stdout, "\x1b[?1049h\x1b[2J\x1b[H")
@@ -188,11 +188,13 @@ func Run(args []string) error {
 		EnableMode: func(mode ansi.Mode) {
 			if mode == ansi.ModeBracketedPaste {
 				state.bracketedPaste = true
+				_, _ = io.WriteString(os.Stdout, ansi.SetModeBracketedPaste)
 			}
 		},
 		DisableMode: func(mode ansi.Mode) {
 			if mode == ansi.ModeBracketedPaste {
 				state.bracketedPaste = false
+				_, _ = io.WriteString(os.Stdout, ansi.ResetModeBracketedPaste)
 			}
 		},
 	})
@@ -451,6 +453,9 @@ type screenState struct {
 	agentInput                          io.Writer
 	bracketedPaste, pastePending        bool
 	pasteInput                          []byte
+	terminalPasting                     bool
+	terminalPasteToAgent                bool
+	terminalPasteMarker                 int
 	mouseDragging                       bool
 }
 
@@ -463,19 +468,61 @@ func (s *screenState) visibleLines() int {
 	return lines
 }
 func (s *screenState) handleInput(data []byte, child io.Writer) {
-	// Closing the app must also work while a paste is waiting for the CLI.
-	for _, b := range data {
+	if s.pastePending {
+		// Closing the app must also work while a handoff waits for the CLI.
+		for _, b := range data {
+			if b == 0x11 {
+				s.review.Request = "quit-app"
+				s.pending, s.pasteInput = nil, nil
+				return
+			}
+		}
+		s.pasteInput = append(s.pasteInput, data...)
+		return
+	}
+	// Preserve input chunks: byte-sized PTY writes make large pastes look like
+	// prolonged typing and force the child to redraw for individual characters.
+	forward := make([]byte, 0, len(data))
+	defer func() {
+		if len(forward) > 0 {
+			_, _ = child.Write(forward)
+		}
+	}()
+	for i, b := range data {
+		// Markers can straddle any stdin read. Once a paste starts, its bytes
+		// belong to the original pane, including newlines and app shortcuts.
+		wasPasting := s.terminalPasting
+		marker := ansi.BracketedPasteStart
+		if wasPasting {
+			marker = ansi.BracketedPasteEnd
+		}
+		if b == marker[s.terminalPasteMarker] {
+			s.terminalPasteMarker++
+		} else {
+			s.terminalPasteMarker = 0
+			if b == marker[0] {
+				s.terminalPasteMarker = 1
+			}
+		}
+		if s.terminalPasteMarker == len(marker) {
+			s.terminalPasteMarker = 0
+			s.terminalPasting = !wasPasting
+			if !wasPasting {
+				s.terminalPasteToAgent = !s.diffFocused
+				s.pending = nil
+			}
+		}
+		if wasPasting || s.terminalPasting {
+			if s.terminalPasteToAgent {
+				forward = append(forward, b)
+			}
+			continue
+		}
 		if b == 0x11 {
 			s.review.Request = "quit-app"
 			s.pending, s.pasteInput = nil, nil
 			return
 		}
-	}
-	if s.pastePending {
-		s.pasteInput = append(s.pasteInput, data...)
-		return
-	}
-	for i, b := range data {
 		if b == 0x07 { // Switch focus without discarding the open file or selection.
 			s.pending = nil
 			s.mouseDragging = false
@@ -499,13 +546,13 @@ func (s *screenState) handleInput(data []byte, child io.Writer) {
 				}
 				s.review.AgentDraft = false
 			}
-			_, _ = child.Write([]byte{b})
+			forward = append(forward, b)
 			continue
 		}
 		s.pending = append(s.pending, b)
 		s.lastInput = time.Now()
 		s.decodeInput(false)
-		if s.review.Request == "paste-agent" || s.review.Request == "paste-context" {
+		if s.review.Request == "paste-agent" || s.review.Request == "paste-context" || s.review.Request == "paste-checkpoint" {
 			s.pasteInput = append(s.pasteInput, data[i+1:]...)
 			return
 		}
@@ -593,7 +640,7 @@ func readPTY(ptmx *os.File, events chan<- any, stop <-chan struct{}) {
 }
 
 func readInput(events chan<- any) {
-	buffer := make([]byte, 256)
+	buffer := make([]byte, 4096)
 	for {
 		n, err := os.Stdin.Read(buffer)
 		if n > 0 {

--- a/internal/app/checkpoint_test.go
+++ b/internal/app/checkpoint_test.go
@@ -1,0 +1,124 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/nccapo/stvena/internal/diffview"
+)
+
+func TestCheckpointActionsUseSessionCaptureAndProtectPin(t *testing.T) {
+	s := pasteState(&bytes.Buffer{})
+	s.sessionView = s.review.Snapshot
+	s.sessionView.Finish()
+	s.review.Source = "workspace"
+	s.review.Key("K", 10)
+	events, stop := make(chan any, 1), make(chan struct{})
+	s.dispatch(context.Background(), events, stop)
+	if s.review.Checkpoint == nil || s.review.Source != "session" || s.review.Snapshot.Version != s.sessionView.Version {
+		t.Fatal("checkpoint did not start on captured session")
+	}
+	for _, request := range []string{"2", "3", "since-review", "problem-open"} {
+		s.review.Request = request
+		s.dispatch(context.Background(), events, stop)
+		if !s.review.Pinned || s.review.Source != "session" || s.review.Snapshot.Version != s.sessionView.Version {
+			t.Fatalf("%s replaced checkpoint", request)
+		}
+	}
+}
+
+func TestCheckpointHandoffPreparesOneLiteralDraft(t *testing.T) {
+	for _, agent := range []string{"codex", "claude"} {
+		t.Run(agent, func(t *testing.T) {
+			var child bytes.Buffer
+			child.WriteString("existing input")
+			s := pasteState(&child)
+			s.agentName = agent
+			if err := s.review.StartCheckpoint(s.review.Snapshot); err != nil {
+				t.Fatal(err)
+			}
+			s.review.Key(" ", 10)
+			s.review.ContextQuestion = "Correct the edge case."
+			s.review.Key("Z", 10)
+			draft := s.review.Checkpoint.Draft
+			events, stop := make(chan any, 1), make(chan struct{})
+			s.handleInput([]byte("bAnd explain why"), &child)
+			if s.review.Request != "paste-checkpoint" {
+				t.Fatal("typing overwrote checkpoint handoff")
+			}
+			s.dispatch(context.Background(), events, stop)
+			e := awaitPaste(t, events)
+			s.workers.Wait()
+			if e.err != nil {
+				t.Fatal(e.err)
+			}
+			if want := "existing input" + ansi.BracketedPasteStart + draft + ansi.BracketedPasteEnd; child.String() != want {
+				t.Fatalf("handoff submitted, lost or changed draft: %q", child.String())
+			}
+			s.finishAgentPaste(e.err)
+			if s.diffFocused || !s.review.AgentDraft || !s.review.Pinned {
+				t.Fatal("handoff lost draft focus or checkpoint pin")
+			}
+			queued := s.pasteInput
+			s.pasteInput = nil
+			s.handleInput(queued, &child)
+			if !strings.HasSuffix(child.String(), ansi.BracketedPasteEnd+"And explain why") {
+				t.Fatal("follow-up input lost")
+			}
+		})
+	}
+}
+
+func TestStandaloneCheckpointExportsWithoutAgentHandoff(t *testing.T) {
+	dir := t.TempDir()
+	output := filepath.Join(dir, "clipboard.txt")
+	for _, name := range []string{"pbcopy", "wl-copy", "xclip", "xsel"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/sh\n/bin/cat > '"+output+"'\n"), 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", dir)
+	var child bytes.Buffer
+	s := pasteState(&child)
+	s.exited = true
+	if err := s.review.StartCheckpoint(s.review.Snapshot); err != nil {
+		t.Fatal(err)
+	}
+	s.review.Key(" ", 10)
+	s.review.Key("Z", 10)
+	s.review.Key("b", 10)
+	events, stop := make(chan any, 1), make(chan struct{})
+	s.dispatch(context.Background(), events, stop)
+	select {
+	case e := <-events:
+		operation, ok := e.(operationEvent)
+		if !ok || operation.err != nil {
+			t.Fatalf("export failed or attempted handoff: %+v", e)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("export stalled")
+	}
+	s.workers.Wait()
+	got, err := os.ReadFile(output)
+	if err != nil || string(got) != s.review.Checkpoint.Draft || child.Len() != 0 || s.pastePending {
+		t.Fatalf("standalone draft not exported: %v", err)
+	}
+}
+
+func TestCheckpointIgnoresLateProblemNavigation(t *testing.T) {
+	s := pasteState(&bytes.Buffer{})
+	if err := s.review.StartCheckpoint(s.review.Snapshot); err != nil {
+		t.Fatal(err)
+	}
+	s.review.Panel = "Problems"
+	s.applyProblem(problemEvent{snapshot: diffview.Snapshot{Tree: "other"}})
+	if s.review.Source != "session" || s.review.Snapshot.Tree != s.review.Checkpoint.Snapshot.Tree || !s.review.Pinned {
+		t.Fatal("late problem result replaced checkpoint")
+	}
+}

--- a/internal/app/problems.go
+++ b/internal/app/problems.go
@@ -123,6 +123,10 @@ func (s *screenState) applyProblem(e problemEvent) {
 	if s.review.Panel != "Problems" {
 		return
 	}
+	if s.review.Checkpoint != nil {
+		s.review.Notice = "Checkpoint stays pinned · P: resume live to open tested source"
+		return
+	}
 	// Keep the tested tree visible even when the live working copy is newer.
 	s.review.Pinned = false
 	s.review.Scope = 0

--- a/internal/app/workspace.go
+++ b/internal/app/workspace.go
@@ -120,6 +120,28 @@ func (s *screenState) dispatch(ctx context.Context, events chan<- any, stop <-ch
 		}
 	}
 	switch r {
+	case "checkpoint":
+		if err := s.review.StartCheckpoint(s.sessionView); err != nil {
+			s.review.Notice = err.Error()
+		}
+	case "paste-checkpoint", "copy-checkpoint":
+		if s.review.Checkpoint == nil || s.review.Checkpoint.Draft == "" {
+			s.review.Notice = "Finish the checkpoint to preview its draft first"
+			break
+		}
+		if r == "paste-checkpoint" && !s.exited && s.agentInput != nil && s.agentName != "" {
+			s.pasteToAgent(events, stop)
+			return false
+		}
+		// Standalone reviews and unsupported commands use the existing clipboard.
+		// Keep the draft open even if the clipboard is unavailable.
+		s.pasteInput = nil
+		value := s.review.Checkpoint.Draft
+		s.workers.Add(1)
+		go func() {
+			defer s.workers.Done()
+			send("Checkpoint draft copied · paste and submit when ready · P: resume live", copyText(value))
+		}()
 	case "quit-app":
 		return true
 	case "paste-agent", "paste-context":
@@ -141,6 +163,10 @@ func (s *screenState) dispatch(ctx context.Context, events chan<- any, stop <-ch
 		}
 		s.relayout(s.layout.Width, s.layout.Height)
 	case "1", "2", "3":
+		if s.review.Checkpoint != nil {
+			s.review.Notice = "Checkpoint stays pinned · Z: finish · P: resume live before switching sources"
+			break
+		}
 		if r == "1" && s.session == nil {
 			s.review.Notice = "No session baseline available"
 			break
@@ -197,6 +223,10 @@ func (s *screenState) dispatch(ctx context.Context, events chan<- any, stop <-ch
 		s.workers.Add(1)
 		go func() { defer s.workers.Done(); send("Opened working file in editor", openEditor(path, n)) }()
 	case "since-review":
+		if s.review.Checkpoint != nil {
+			s.review.Notice = "Checkpoint stays pinned · P: resume live before comparing history"
+			break
+		}
 		f := s.review.Current()
 		if f == nil {
 			break
@@ -229,6 +259,10 @@ func (s *screenState) dispatch(ctx context.Context, events chan<- any, stop <-ch
 		s.review.Scroll = 0
 		s.review.Notice = "Changes since last review · P returns to live"
 	case "problem-open", "problem-add":
+		if r == "problem-open" && s.review.Checkpoint != nil {
+			s.review.Notice = "Checkpoint stays pinned · x: collect failure · P: resume live to open tested source"
+			break
+		}
 		s.loadProblem(r == "problem-add", events, stop)
 	case "check":
 		if s.review.CheckRunning {

--- a/internal/review/actions.go
+++ b/internal/review/actions.go
@@ -13,6 +13,8 @@ import (
 type Action struct{ Key, Name, Hint string }
 
 var Actions = []Action{
+	{"K", "Review checkpoint", "Pin current session changes and review them before the next prompt"},
+	{"Z", "Finish checkpoint", "Preview comments and collected context, then paste or copy one draft"},
 	{"v", "Diff / full file", "Read changed lines or the complete file"},
 	{"F", "Focus review", "Expand review to the full terminal"},
 	{"1", "This session", "Changes observed since the agent started"},
@@ -49,7 +51,11 @@ var Actions = []Action{
 func (s *State) AdvancedKey(key string, visible int) bool {
 	if s.ConfirmAction != "" {
 		if key == "enter" {
-			s.Request = "confirm:" + s.ConfirmAction
+			if s.ConfirmAction == "finish-checkpoint" {
+				s.FinishCheckpoint(true)
+			} else {
+				s.Request = "confirm:" + s.ConfirmAction
+			}
 			s.ConfirmAction = ""
 		} else if key == "esc" {
 			s.ConfirmAction = ""
@@ -129,7 +135,32 @@ func (s *State) AdvancedKey(key string, visible int) bool {
 		}
 		return true
 	}
+	if key == "Z" && s.Checkpoint != nil {
+		s.Panel = ""
+		s.FinishCheckpoint(false)
+		return true
+	}
 	if s.contextKey(key, visible) {
+		return true
+	}
+	if s.Panel == "Checkpoint draft" {
+		switch key {
+		case "b", "y":
+			s.Request = map[string]string{"b": "paste-checkpoint", "y": "copy-checkpoint"}[key]
+		case "i":
+			s.Panel = "Context"
+			s.Prompt, s.Input = "Context request", s.ContextQuestion
+		case "esc":
+			s.Panel, s.PanelScroll = "", 0
+		case "j", "down":
+			s.PanelScroll++
+		case "k", "up":
+			s.PanelScroll = max(0, s.PanelScroll-1)
+		case "d", "pagedown":
+			s.PanelScroll += max(1, visible/2)
+		case "u", "pageup":
+			s.PanelScroll = max(0, s.PanelScroll-max(1, visible/2))
+		}
 		return true
 	}
 	if s.Panel == "Problems" {
@@ -188,6 +219,10 @@ func (s *State) AdvancedKey(key string, visible int) bool {
 		return true
 	}
 	switch key {
+	case "K":
+		s.Request = "checkpoint"
+	case "Z":
+		s.FinishCheckpoint(false)
 	case "N":
 		if len(s.Indices) == 0 {
 			s.Notice = "No files to review in this view"
@@ -295,6 +330,11 @@ func (s *State) AdvancedKey(key string, visible int) bool {
 	case "w":
 		s.Wrap = !s.Wrap
 	case "P":
+		if s.Checkpoint != nil {
+			s.ResumeCheckpoint()
+			s.Notice = "Live updates resumed · changed versions need review again"
+			return true
+		}
 		if s.Snapshot.Tree == "" && !s.Pinned {
 			s.Notice = "Pinning needs a captured version; wait for session capture"
 			return true
@@ -327,7 +367,14 @@ func (s *State) AdvancedKey(key string, visible int) bool {
 			s.Hunks = map[string]bool{}
 		}
 		id := HunkID(*f, h)
-		s.Hunks[id] = !s.Hunks[id]
+		wasReviewed := s.HunkReviewed(*f, h)
+		if hash, ok := s.reviewed[f.Key()]; ok && hash == fingerprint(*f) {
+			for h := range hunks {
+				s.Hunks[HunkID(*f, h)] = true
+			}
+		}
+		delete(s.reviewed, f.Key())
+		s.Hunks[id] = !wasReviewed
 		s.Remember(*f)
 		s.Notice = "Hunk review updated"
 		s.Request = "save"

--- a/internal/review/checkpoint.go
+++ b/internal/review/checkpoint.go
@@ -1,0 +1,197 @@
+package review
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nccapo/stvena/internal/diffview"
+)
+
+// Checkpoint keeps the reviewed tree and its patch together across refreshes
+// and restarts. Marks and feedback still belong to the existing review systems.
+type Checkpoint struct {
+	Snapshot               diffview.Snapshot
+	StaleFiles, StaleHunks map[string]bool
+	Draft                  string
+}
+
+func (s *State) StartCheckpoint(snapshot diffview.Snapshot) error {
+	if s.Checkpoint != nil {
+		return fmt.Errorf("Checkpoint already pinned · Z: finish · P: resume live")
+	}
+	if snapshot.Tree == "" || snapshot.Err != nil {
+		return fmt.Errorf("Review checkpoint needs a successful session capture")
+	}
+	// Own the slices as well as the immutable Git object references.
+	snapshot.Files = append([]diffview.File(nil), snapshot.Files...)
+	for i := range snapshot.Files {
+		snapshot.Files[i].Lines = append([]string(nil), snapshot.Files[i].Lines...)
+	}
+	s.Pinned, s.selectionPinned = false, false
+	s.ClearSelection()
+	s.Source = "session"
+	s.Scope, s.Selected, s.Scroll, s.Horizontal = 0, 0, 0, 0
+	s.Query, s.Panel, s.ContentKey = "", "", ""
+	s.FullFile, s.Browser, s.PatchFocused = false, true, false
+	s.Update(snapshot)
+	s.Checkpoint = &Checkpoint{Snapshot: snapshot, StaleFiles: map[string]bool{}, StaleHunks: map[string]bool{}}
+	s.Pinned, s.PinnedVersion = true, snapshot.Version
+	s.Notice = "Checkpoint pinned · Space/H: reviewed · c: comment · x: collect · Z: finish"
+	return nil
+}
+
+func (s *State) CheckpointNewer() bool {
+	return s.Checkpoint != nil && (s.LiveTree != "" && s.LiveTree != s.Checkpoint.Snapshot.Tree ||
+		s.Latest.Tree != "" && (s.Latest.Tree != s.Checkpoint.Snapshot.Tree || s.Latest.Version != s.Checkpoint.Snapshot.Version))
+}
+
+func (s *State) observeCheckpoint(live diffview.Snapshot) {
+	c := s.Checkpoint
+	if c == nil || live.Err != nil || live.Tree == "" {
+		return
+	}
+	if c.StaleFiles == nil {
+		c.StaleFiles = map[string]bool{}
+	}
+	if c.StaleHunks == nil {
+		c.StaleHunks = map[string]bool{}
+	}
+	files, hunks := map[string]diffview.File{}, map[string]bool{}
+	for _, f := range live.Files {
+		files[f.Key()] = f
+		for h := range HunkRanges(f.Lines) {
+			hunks[HunkID(f, h)] = true
+		}
+	}
+	for _, f := range c.Snapshot.Files {
+		current, ok := files[f.Key()]
+		if !ok || fingerprint(current) != fingerprint(f) {
+			c.StaleFiles[f.Key()] = true
+		}
+		for h := range HunkRanges(f.Lines) {
+			id := HunkID(f, h)
+			if !hunks[id] {
+				c.StaleHunks[id] = true
+			}
+		}
+	}
+}
+
+func (s *State) ResumeCheckpoint() {
+	if c := s.Checkpoint; c != nil {
+		for key := range c.StaleFiles {
+			delete(s.reviewed, key)
+		}
+		for id := range c.StaleHunks {
+			delete(s.Hunks, id)
+		}
+	}
+	s.Checkpoint = nil
+	s.Pinned, s.selectionPinned = false, false
+	s.ClearSelection()
+	s.Panel = ""
+	// A saved checkpoint can be resumed before the first live capture arrives.
+	if s.Latest.Tree != "" {
+		s.Update(s.Latest)
+	}
+	s.Request = "save"
+}
+
+func (s *State) HunkReviewed(f diffview.File, h int) bool {
+	if hash, ok := s.reviewed[f.Key()]; ok && hash == fingerprint(f) {
+		return true
+	}
+	return s.Hunks[HunkID(f, h)]
+}
+
+func (s *State) CheckpointProgress() (files, totalFiles, hunks, totalHunks int) {
+	if s.Checkpoint == nil {
+		return
+	}
+	for _, f := range s.Checkpoint.Snapshot.Files {
+		totalFiles++
+		if s.Reviewed(f) {
+			files++
+		}
+		for h := range HunkRanges(f.Lines) {
+			totalHunks++
+			if s.HunkReviewed(f, h) {
+				hunks++
+			}
+		}
+	}
+	return
+}
+
+func (s *State) CheckpointComments() []Comment {
+	var comments []Comment
+	if s.Checkpoint != nil {
+		for _, c := range s.Comments {
+			if c.Tree == s.Checkpoint.Snapshot.Tree {
+				comments = append(comments, c)
+			}
+		}
+	}
+	return comments
+}
+
+func (s *State) FinishCheckpoint(allowIncomplete bool) {
+	if s.Checkpoint == nil {
+		s.Notice = "Start a Review checkpoint from Actions (K) first"
+		return
+	}
+	f, tf, h, th := s.CheckpointProgress()
+	if !allowIncomplete && (f < tf || h < th || s.Checkpoint.Snapshot.Approximate) {
+		s.ConfirmAction = "finish-checkpoint"
+		s.ConfirmDetail = fmt.Sprintf("%d files / %d hunks still unreviewed. Incomplete previews also need review.", tf-f, th-h)
+		return
+	}
+	message, err := s.CheckpointMessage()
+	if err != nil {
+		s.Notice = err.Error()
+		return
+	}
+	s.Checkpoint.Draft = message
+	s.Panel, s.PanelScroll = "Checkpoint draft", 0
+	s.Request = "save"
+}
+
+func (s *State) CheckpointMessage() (string, error) {
+	if s.Checkpoint == nil {
+		return "", fmt.Errorf("No checkpoint to finish")
+	}
+	c := s.Checkpoint
+	f, tf, h, th := s.CheckpointProgress()
+	var out strings.Builder
+	fmt.Fprintf(&out, "\nReview checkpoint\nCaptured version: %s\nWorking-copy snapshot: %s\nReview progress: %d/%d files; %d/%d hunks.\n", c.Snapshot.Version, c.Snapshot.Tree, f, tf, h, th)
+	fmt.Fprintf(&out, "Repository: %q\n", c.Snapshot.Root)
+	if f < tf || h < th || c.Snapshot.Approximate {
+		out.WriteString("Review is incomplete; unreviewed or truncated changes are not approved.\n")
+	}
+	out.WriteString("This review applies only to the captured version. Verify current files before editing; later changes have not been reviewed.\n")
+	if s.CheckpointNewer() {
+		out.WriteString("A newer live version exists.\n")
+	}
+	feedback := *s
+	feedback.Comments = s.CheckpointComments()
+	if len(feedback.Comments) > 0 {
+		out.WriteString("\n" + feedback.ExportFeedback())
+	}
+	if len(s.Attachments) > 0 {
+		context, err := s.ContextMessage()
+		if err != nil {
+			return "", err
+		}
+		out.WriteString(context)
+	} else if strings.TrimSpace(s.ContextQuestion) != "" {
+		fmt.Fprintf(&out, "\nMy request:\n%s\n", s.ContextQuestion)
+	}
+	if len(feedback.Comments) == 0 && len(s.Attachments) == 0 && strings.TrimSpace(s.ContextQuestion) == "" {
+		out.WriteString("No corrections were recorded in this checkpoint.\n")
+	}
+	message := pasteText(out.String())
+	if len(message) > 32<<10 {
+		return "", fmt.Errorf("Checkpoint draft exceeds 32 KiB; shorten feedback or remove context attachments")
+	}
+	return message, nil
+}

--- a/internal/review/checkpoint_test.go
+++ b/internal/review/checkpoint_test.go
@@ -1,0 +1,233 @@
+package review
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nccapo/stvena/internal/diffview"
+	"github.com/nccapo/stvena/internal/session"
+)
+
+func checkpointSnapshot() diffview.Snapshot {
+	s := diffview.Snapshot{Tree: strings.Repeat("a", 40), Files: []diffview.File{
+		{Path: "src/a.go", Scope: diffview.Session, Lines: []string{"@@ -1 +1 @@", "-oldA()", "+newA()", "@@ -9 +9 @@", "-oldB()", "+newB()"}},
+		{Path: "src/b.go", Scope: diffview.Session, Lines: []string{"@@ -3 +3 @@", "-oldC()", "+newC()"}},
+	}}
+	s.Finish()
+	return s
+}
+
+func TestCheckpointPinsAndCountsExistingMarks(t *testing.T) {
+	var s State
+	view := checkpointSnapshot()
+	s.Update(view)
+	s.Key(" ", 10)
+	s.Key("V", 10) // An existing temporary selection pin becomes explicit.
+	if err := s.StartCheckpoint(view); err != nil {
+		t.Fatal(err)
+	}
+	s.Key("V", 10)
+	s.Key("V", 10)
+	if !s.Pinned || s.Snapshot.Tree != view.Tree {
+		t.Fatal("selection released checkpoint")
+	}
+	f, tf, h, th := s.CheckpointProgress()
+	if f != 1 || tf != 2 || h != 2 || th != 3 {
+		t.Fatalf("progress: %d/%d files, %d/%d hunks", f, tf, h, th)
+	}
+	s.Key("N", 10)
+	if s.Current().Path != "src/b.go" {
+		t.Fatal("next unreviewed missed second file")
+	}
+	s.Key("H", 10)
+	if f, _, h, _ := s.CheckpointProgress(); f != 2 || h != 3 {
+		t.Fatal("hunk mark did not update progress")
+	}
+	s.Key("p", 10)
+	s.Key("H", 10)
+	if s.Reviewed(*s.Current()) || s.HunkReviewed(*s.Current(), 0) || !s.HunkReviewed(*s.Current(), 1) {
+		t.Fatal("unmarking one hunk did not preserve the other file-level reviewed hunk")
+	}
+	view.Files[0].Lines[2] = "+mutated()"
+	if s.Snapshot.Files[0].Lines[2] != "+newA()" {
+		t.Fatal("checkpoint aliases source slices")
+	}
+}
+
+func TestCheckpointLiveChangesStayUnreviewedEvenAfterRevert(t *testing.T) {
+	for _, revert := range []bool{false, true} {
+		var s State
+		original := checkpointSnapshot()
+		if err := s.StartCheckpoint(original); err != nil {
+			t.Fatal(err)
+		}
+		s.Key(" ", 10)
+		live := checkpointSnapshot()
+		live.Tree = strings.Repeat("b", 40)
+		live.Files[0].Lines[2] = "+newer()"
+		live.Finish()
+		s.Update(live)
+		if !s.CheckpointNewer() || s.Snapshot.Tree != original.Tree || !s.Reviewed(*s.Current()) {
+			t.Fatal("live update replaced checkpoint or its marks")
+		}
+		if revert {
+			s.Update(original)
+		}
+		s.Key("P", 10)
+		if s.Pinned || s.Checkpoint != nil || s.Reviewed(*s.Current()) || s.HunkReviewed(*s.Current(), 0) {
+			t.Fatal("changed hunk inherited checkpoint review")
+		}
+		if !s.HunkReviewed(*s.Current(), 1) {
+			t.Fatal("unchanged hunk lost review")
+		}
+	}
+}
+
+func TestCheckpointDraftCombinesExactCommentsAndContext(t *testing.T) {
+	var s State
+	if err := s.StartCheckpoint(checkpointSnapshot()); err != nil {
+		t.Fatal(err)
+	}
+	for _, text := range []string{"Handle the empty input", "Keep the error"} {
+		s.Key("enter", 10)
+		s.Scroll = 2
+		if err := s.AddComment(text); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.CollectSelection(); err != nil {
+			t.Fatal(err)
+		}
+		s.Key("n", 10)
+	}
+	s.Comments = append(s.Comments, Comment{Tree: "other", Text: "unrelated old comment"})
+	s.ContextQuestion = "Please fix both issues.\x1b[201~\r"
+	s.Key("Z", 10)
+	if s.ConfirmAction != "finish-checkpoint" || s.Checkpoint.Draft != "" {
+		t.Fatal("incomplete review did not warn")
+	}
+	s.Key("esc", 10)
+	if s.Panel != "" || !s.Pinned {
+		t.Fatal("cancel did not return to pinned review")
+	}
+	s.Key("Z", 10)
+	s.Key("enter", 10)
+	if s.Panel != "Checkpoint draft" || s.Request != "save" {
+		t.Fatal("finish did not open preview")
+	}
+	draft := s.Checkpoint.Draft
+	for _, want := range []string{"src/a.go:1-1", "src/b.go:3-3", "Handle the empty input", "Keep the error", "newA()", "newC()", "New lines: 1-1", "New lines: 3-3", s.Snapshot.Tree, s.Snapshot.Version, "Please fix both issues.", "Review is incomplete"} {
+		if !strings.Contains(draft, want) {
+			t.Errorf("draft missing %q", want)
+		}
+	}
+	if strings.Contains(draft, "unrelated old comment") || strings.ContainsAny(draft, "\x1b\r") {
+		t.Fatal("draft contains unrelated comments or terminal controls")
+	}
+	before := draft
+	live := checkpointSnapshot()
+	live.Tree = "new live"
+	s.Update(live)
+	if s.Checkpoint.Draft != before {
+		t.Fatal("live update replaced previewed draft")
+	}
+}
+
+func TestCheckpointCompleteFinishAndCaptureGuard(t *testing.T) {
+	var s State
+	if err := s.StartCheckpoint(diffview.Snapshot{}); err == nil || s.Pinned {
+		t.Fatal("uncaptured checkpoint accepted")
+	}
+	if err := s.StartCheckpoint(checkpointSnapshot()); err != nil {
+		t.Fatal(err)
+	}
+	s.Key(" ", 10)
+	s.Key("n", 10)
+	s.Key(" ", 10)
+	s.Key("Z", 10)
+	if s.ConfirmAction != "" || s.Panel != "Checkpoint draft" || strings.Contains(s.Checkpoint.Draft, "Review is incomplete") {
+		t.Fatal("complete review did not go straight to draft")
+	}
+}
+
+func TestSavedCheckpointReopensCapturedCodeAndStaleMarks(t *testing.T) {
+	root := t.TempDir()
+	if out, err := exec.Command("git", "init", "-q", root).CombinedOutput(); err != nil {
+		t.Fatalf("%s: %v", out, err)
+	}
+	write := func(text string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(root, "file.txt"), []byte(text), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("before\n")
+	saved, err := session.Open(root, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer saved.Close()
+	write("captured\n")
+	tree, err := saved.Capture()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var s State
+	if err := s.Load(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.StartCheckpoint(diffview.CompareTrees(root, saved.Baseline, tree)); err != nil {
+		t.Fatal(err)
+	}
+	s.Key(" ", 10)
+	s.Key("enter", 10)
+	s.Scroll = len(s.DisplayLines()) - 1
+	if err := s.AddComment("Fix this exact line"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CollectSelection(); err != nil {
+		t.Fatal(err)
+	}
+	s.Key("Z", 10)
+	write("live\n")
+	liveTree, err := saved.Capture()
+	if err != nil {
+		t.Fatal(err)
+	}
+	live := diffview.CompareTrees(root, saved.Baseline, liveTree)
+	s.Update(live)
+	if err := s.Save(); err != nil {
+		t.Fatal(err)
+	}
+	var reopened State
+	if err := reopened.Load(root); err != nil {
+		t.Fatal(err)
+	}
+	reopened.Update(live)
+	if !reopened.Pinned || reopened.Snapshot.Tree != tree || reopened.ReviewedCount() != 1 || !reopened.CheckpointNewer() || reopened.Checkpoint.Draft != s.Checkpoint.Draft {
+		t.Fatal("saved checkpoint state not restored")
+	}
+	content := diffview.LoadContent(root, *reopened.Current())
+	if content.Err != nil || strings.Join(content.Lines, "\n") != "captured" {
+		t.Fatalf("reopened file is not captured code: %+v", content)
+	}
+	if len(reopened.CheckpointComments()) != 1 || len(reopened.Attachments) != 1 {
+		t.Fatal("saved feedback lost")
+	}
+	reopened.Key("P", 10)
+	if reopened.ReviewedCount() != 0 {
+		t.Fatal("reopened live version claimed reviewed")
+	}
+	if err := reopened.Save(); err != nil {
+		t.Fatal(err)
+	}
+	var resumed State
+	if err := resumed.Load(root); err != nil {
+		t.Fatal(err)
+	}
+	if resumed.Checkpoint != nil {
+		t.Fatal("resumed checkpoint reopened again")
+	}
+}

--- a/internal/review/persist.go
+++ b/internal/review/persist.go
@@ -24,6 +24,7 @@ type Record struct {
 	At   time.Time
 }
 type Saved struct {
+	Checkpoint      *Checkpoint `json:",omitempty"`
 	Reviewed        map[string][32]byte
 	Hunks           map[string]bool
 	History         map[string]Record
@@ -55,6 +56,15 @@ func (s *State) Load(root string) error {
 	}
 	s.Attachments, s.ContextQuestion = saved.Attachments, saved.ContextQuestion
 	s.reviewed, s.Hunks, s.History, s.Comments, s.LastCheck = saved.Reviewed, saved.Hunks, saved.History, saved.Comments, saved.LastCheck
+	if saved.Checkpoint != nil {
+		c := saved.Checkpoint
+		if err := s.StartCheckpoint(c.Snapshot); err != nil {
+			return err
+		}
+		s.Checkpoint = c
+		s.Latest = diffview.Snapshot{}
+		s.Notice = "Saved checkpoint reopened · Z: finish · P: resume live"
+	}
 	return nil
 }
 func (s *State) Save() error {
@@ -89,7 +99,20 @@ func (s *State) Save() error {
 			return err
 		}
 	}
-	return session.AtomicJSON(s.savePath, Saved{Reviewed: s.reviewed, Hunks: s.Hunks, History: s.History, Comments: s.Comments, LastCheck: s.LastCheck, Attachments: s.Attachments, ContextQuestion: s.ContextQuestion})
+	if s.Checkpoint != nil {
+		if err := retain(s.Checkpoint.Snapshot.Tree); err != nil {
+			return err
+		}
+		// Removed files and old-side full-file views also need their blobs retained.
+		for _, f := range s.Checkpoint.Snapshot.Files {
+			if strings.Trim(f.BeforeOID, "0") != "" {
+				if err := retain(f.BeforeOID); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return session.AtomicJSON(s.savePath, Saved{Checkpoint: s.Checkpoint, Reviewed: s.reviewed, Hunks: s.Hunks, History: s.History, Comments: s.Comments, LastCheck: s.LastCheck, Attachments: s.Attachments, ContextQuestion: s.ContextQuestion})
 }
 func (s *State) Remember(f diffview.File) {
 	if s.History == nil {

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -30,6 +30,7 @@ type State struct {
 	Latest                            diffview.Snapshot
 	Pinned, SideBySide, Wrap          bool
 	PinnedVersion                     string
+	Checkpoint                        *Checkpoint
 	selectionPinned                   bool
 	Menu                              bool
 	MenuIndex                         int
@@ -80,6 +81,7 @@ func (s *State) Current() *diffview.File {
 func (s *State) Update(snapshot diffview.Snapshot) {
 	s.Latest = snapshot
 	if s.Pinned {
+		s.observeCheckpoint(snapshot)
 		return
 	}
 	key := ""
@@ -107,7 +109,19 @@ func (s *State) Update(snapshot diffview.Snapshot) {
 			delete(s.reviewed, key)
 		}
 	}
-
+	// Hunk marks must not revive if changed code later returns to an old patch.
+	activeHunks := map[string]bool{}
+	for _, f := range snapshot.Files {
+		for h := range HunkRanges(f.Lines) {
+			activeHunks[HunkID(f, h)] = true
+		}
+	}
+	for id := range s.Hunks {
+		isSession := strings.HasPrefix(id, string(diffview.Session)+"\x00")
+		if (s.Source == "" || isSession == (s.Source == "session")) && !activeHunks[id] {
+			delete(s.Hunks, id)
+		}
+	}
 }
 func (s *State) filter(key string) {
 	s.Indices = nil
@@ -415,6 +429,12 @@ func (s *State) Key(key string, visible int) {
 				}
 			} else {
 				s.reviewed[f.Key()] = fingerprint(*f)
+				if s.Hunks == nil {
+					s.Hunks = map[string]bool{}
+				}
+				for h := range HunkRanges(f.Lines) {
+					s.Hunks[HunkID(*f, h)] = true
+				}
 				s.Remember(*f)
 			}
 		}

--- a/internal/ui/checkpoint_test.go
+++ b/internal/ui/checkpoint_test.go
@@ -1,0 +1,46 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/nccapo/stvena/internal/diffview"
+	"github.com/nccapo/stvena/internal/review"
+)
+
+func TestCheckpointProgressAndFinishWarning(t *testing.T) {
+	var s review.State
+	view := diffview.Snapshot{Tree: "captured", Files: []diffview.File{{Path: "file.go", Scope: diffview.Session, Lines: []string{"@@ -1 +1 @@", "-old", "+new"}}}}
+	view.Finish()
+	if err := s.StartCheckpoint(view); err != nil {
+		t.Fatal(err)
+	}
+	s.Notice = ""
+	s.Update(diffview.Snapshot{Tree: "newer"})
+	render := func() string { return ansi.Strip(strings.Join(renderReview(&s, 64, 18, true), "\n")) }
+	for _, want := range []string{"Checkpoint · 0/1 files · 0/1 hunks", "Pinned · NEW LIVE", "0 comments · 0 selections", "Z: Finish checkpoint", "P: Resume live"} {
+		if !strings.Contains(render(), want) {
+			t.Errorf("missing %q: %s", want, render())
+		}
+	}
+	s.Key("Z", 10)
+	if got := render(); !strings.Contains(got, "review incomplete") || !strings.Contains(got, "Esc: return to review") || strings.Contains(got, "staging index") {
+		t.Fatalf("wrong warning: %s", got)
+	}
+	s.Key("esc", 10)
+	s.Key(" ", 10)
+	if !strings.Contains(render(), "Checkpoint · 1/1 files · 1/1 hunks") {
+		t.Fatal("progress did not update")
+	}
+	seen := map[string]bool{}
+	for _, a := range review.Actions {
+		if seen[a.Key] {
+			t.Fatalf("conflicting action shortcut %q", a.Key)
+		}
+		seen[a.Key] = true
+	}
+	if !seen["K"] || !seen["Z"] {
+		t.Fatal("checkpoint actions not discoverable")
+	}
+}

--- a/internal/ui/overlays.go
+++ b/internal/ui/overlays.go
@@ -14,6 +14,10 @@ func renderOverlay(s *review.State, width, height int) []string {
 	case s.ConfirmAction != "":
 		title = "Confirm Git action"
 		content = []string{"", safeText(s.ConfirmDetail), "", "Enter confirms · Esc cancels", "", "Only the staging index will change."}
+		if s.ConfirmAction == "finish-checkpoint" {
+			title = "Finish checkpoint · review incomplete"
+			content = []string{"", safeText(s.ConfirmDetail), "", "Esc: return to review", "Enter: preview draft anyway", "", "Previewing does not submit anything to the agent."}
+		}
 	case s.Prompt != "":
 		title = s.Prompt
 		content = []string{"", cyan + horizontalText(safeText(s.Input), max(0, ansiWidth(safeText(s.Input))-max(1, width-4))) + "▏", "", "Enter: submit · Esc: cancel"}
@@ -101,6 +105,18 @@ func renderOverlay(s *review.State, width, height int) []string {
 			content = []string{err.Error()}
 		} else {
 			for _, line := range strings.Split(message, "\n") {
+				content = append(content, strings.Split(ansi.Hardwrap(safeText(line), max(1, width-2), true), "\n")...)
+			}
+		}
+	case s.Panel == "Checkpoint draft":
+		title = "Review checkpoint · draft preview"
+		if s.CheckpointNewer() {
+			title += " · NEW LIVE"
+		}
+		footer = " b: paste / export · y: copy · Esc: return to review"
+		if s.Checkpoint != nil {
+			content = []string{"b prepares agent input without submitting.", "Standalone review copies the draft instead.", "P resumes live after returning to review.", ""}
+			for _, line := range strings.Split(s.Checkpoint.Draft, "\n") {
 				content = append(content, strings.Split(ansi.Hardwrap(safeText(line), max(1, width-2), true), "\n")...)
 			}
 		}

--- a/internal/ui/review.go
+++ b/internal/ui/review.go
@@ -41,7 +41,10 @@ func renderReview(s *review.State, width, height int, focused bool) []string {
 	if s.Snapshot.FileCount == 1 {
 		noun = "file"
 	}
-	if s.Source == "project" {
+	if s.Checkpoint != nil {
+		f, tf, h, th := s.CheckpointProgress()
+		add(bg + bold + fmt.Sprintf(" Checkpoint · %d/%d files · %d/%d hunks", f, tf, h, th))
+	} else if s.Source == "project" {
 		add(bg + bold + fmt.Sprintf(" Project · %d %s", s.Snapshot.FileCount, noun) + reset + muted + "  /: find file")
 	} else {
 		add(bg + bold + fmt.Sprintf(" %d %s  %s+%d -%d", s.Snapshot.FileCount, noun, approx, s.Snapshot.Added, s.Snapshot.Deleted) + reset + bg + "  " + safeText(s.Snapshot.Branch))
@@ -84,7 +87,16 @@ func renderReview(s *review.State, width, height int, focused bool) []string {
 		if s.Source != "session" && s.Source != "project" {
 			source += " · " + scope
 		}
-		if s.Source == "project" {
+		if s.Checkpoint != nil {
+			freshness := "live unchanged"
+			if s.CheckpointNewer() {
+				freshness = "NEW LIVE"
+			}
+			if s.Latest.Tree == "" && !s.CheckpointNewer() {
+				freshness = "checking live…"
+			}
+			add(cyan + fmt.Sprintf(" Pinned · %s · %d comments · %d selections", freshness, len(s.CheckpointComments()), len(s.Attachments)))
+		} else if s.Source == "project" {
 			add(cyan + " " + source + filter)
 		} else {
 			add(cyan + " " + source + fmt.Sprintf(" · %d/%d reviewed", s.ReviewedCount(), len(s.Snapshot.Files)) + filter)

--- a/internal/ui/review_controls.go
+++ b/internal/ui/review_controls.go
@@ -11,6 +11,9 @@ type reviewControl struct{ key, label string }
 
 func reviewControls(s *review.State) []reviewControl {
 	controls := baseReviewControls(s)
+	if s.Checkpoint != nil {
+		return append([]reviewControl{{"Z", "Z: Finish checkpoint"}, {"P", "P: Resume live"}}, controls...)
+	}
 	if s.Pinned && !s.Selecting {
 		controls = append([]reviewControl{{"P", "P: Resume live"}}, controls...)
 	}
@@ -135,7 +138,12 @@ func selectionSummary(s *review.State) string {
 
 func panelControls(s *review.State) []reviewControl {
 	switch s.Panel {
+	case "Checkpoint draft":
+		return []reviewControl{{"b", "b: Paste / export"}, {"y", "y: Copy"}, {"i", "i: Request"}, {"esc", "Esc: Review"}}
 	case "Context":
+		if s.Checkpoint != nil {
+			return []reviewControl{{"Z", "Z: Finish checkpoint"}, {"i", "i: Request"}, {"d", "d: Remove"}, {"esc", "Esc: Back"}}
+		}
 		return []reviewControl{{"enter", "Enter: Preview"}, {"i", "i: Request"}, {"d", "d: Remove"}, {"b", "b: Paste"}, {"esc", "Esc: Back"}}
 	case "Context preview":
 		return []reviewControl{{"b", "b: Paste to agent"}, {"y", "y: Copy"}, {"esc", "Esc: Tray"}}


### PR DESCRIPTION
## Summary

- add persisted review checkpoints that pin a captured session tree and track file/hunk progress
- assemble checkpoint comments, selected context, and requests into a previewable draft for agent or clipboard handoff
- harden bracketed terminal paste handling and keep checkpoint navigation pinned
- document the checkpoint workflow and shortcuts

## Verification

- `test -z "$(gofmt -l cmd internal)"`
- `go vet ./...`
- `go test -race ./...`
- `go build ./...`