### PR TITLE
feat: configure and persist review hotkeys

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -305,6 +305,21 @@ There are no discard, restore, commit, push or branch-editing actions.
 
 ## Controls
 
+Press **?** in review, or click **?: Hotkeys** in the footer, to configure review
+shortcuts. Select an action with **↑/↓** (or **j/k**) and press **Enter**, or click
+its row, then press a replacement printable key. Uppercase and lowercase keys
+are distinct. Conflicting assignments are rejected; move the existing binding
+first to free its key. **Esc** cancels an edit or closes the controls screen.
+**Backspace** restores the selected shortcut; **Delete** restores all defaults.
+Changes apply immediately and save with this repository's layout preferences.
+
+The controls screen, Actions menu and clickable toolbars show your configured
+keys. A shortcut retains its context-dependent behavior (for example, **d**
+scrolls code but removes an attachment in Context). **?**, **j/k**, named
+navigation keys (arrows, Enter, Esc, Tab, Backspace, etc.) and global **Ctrl**
+shortcuts stay fixed. Text entry and input to the agent are unaffected.
+The table below lists defaults.
+
 | Key | Action |
 | --- | --- |
 | Ctrl-G | Switch panes (agent / workspace), preserving the open file and selection |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -610,7 +610,7 @@ func (s *screenState) decodeInput(flush bool) {
 			if s.agentPicker != nil {
 				s.agentPickerKey(key)
 			} else {
-				s.review.Key(key, s.visibleLines())
+				s.review.InputKey(key, s.visibleLines())
 			}
 		}
 	}

--- a/internal/app/hotkeys_test.go
+++ b/internal/app/hotkeys_test.go
@@ -1,0 +1,160 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nccapo/stvena/internal/review"
+	"github.com/nccapo/stvena/internal/session"
+	"github.com/nccapo/stvena/internal/ui"
+)
+
+func TestConfigureHotkeyWithMouseAndPersist(t *testing.T) {
+	s := screenState{root: t.TempDir(), ratio: 58, diffFocused: true}
+	s.relayout(140, 40)
+	var child bytes.Buffer
+	// Click the persistent ? control, then the first action in the editor.
+	clicked := false
+	for y := 0; y < s.layout.FooterHeight && !clicked; y++ {
+		for x := 0; x < s.layout.Width; x++ {
+			if ui.ControlKeyAt(s.layout.Width, x, y, true, &s.review) == "?" {
+				s.mouse(fmt.Sprintf("<0;%d;%dM", x+1, s.layout.FooterY+y+1))
+				clicked = true
+				break
+			}
+		}
+	}
+	if !clicked || !s.review.Help {
+		t.Fatal("clicking ? did not open hotkey configuration")
+	}
+	s.mouse(fmt.Sprintf("<0;%d;%dM", s.layout.DiffX+2, s.layout.DiffY+4))
+	if !s.review.EditingHotkey {
+		t.Fatal("clicking an action did not start editing")
+	}
+	s.mouse(fmt.Sprintf("<65;%d;%dM", s.layout.DiffX+2, s.layout.DiffY+4))
+	if s.review.Notice != "" || !s.review.EditingHotkey {
+		t.Fatal("mouse wheel was captured as a replacement key")
+	}
+	s.handleInput([]byte("r"), &child)
+	s.dispatch(context.Background(), make(chan any, 1), make(chan struct{}))
+	if s.review.Binding("a") != "r" || !strings.Contains(s.review.Notice, "saved") {
+		t.Fatalf("binding was not saved: %s", s.review.Notice)
+	}
+	reopened := screenState{root: s.root, layout: ui.NewLayout(140, 40)}
+	reopened.loadPreferences()
+	if reopened.review.Binding("a") != "r" || reopened.ratio != 58 {
+		t.Fatal("preferences did not restore the custom binding and layout")
+	}
+	s.handleInput([]byte("?r"), &child)
+	if !s.review.Menu {
+		t.Fatal("configured key did not open Actions")
+	}
+	s.diffFocused = false
+	s.handleInput([]byte("ar"), &child)
+	if child.String() != "ar" {
+		t.Fatal("custom bindings altered agent input")
+	}
+}
+
+func TestHotkeyPreferencesRejectConflictsAndReadOldLayout(t *testing.T) {
+	s := screenState{root: t.TempDir(), layout: ui.NewLayout(140, 40)}
+	dir, err := session.RepoDir(s.root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, data := range []string{
+		`{"Ratio":65,"Wrap":true,"SideBySide":true,"Hotkeys":{"v":"w"}}`,
+		`{"Ratio":65,"Wrap":true,"SideBySide":true}`,
+	} {
+		s.review.Hotkeys = map[string]string{"v": "r"}
+		if err := os.WriteFile(filepath.Join(dir, "layout.json"), []byte(data), 0600); err != nil {
+			t.Fatal(err)
+		}
+		s.loadPreferences()
+		if len(s.review.Hotkeys) != 0 || s.ratio != 65 || !s.review.Wrap || !s.review.SideBySide {
+			t.Fatal("invalid or absent hotkeys broke existing preferences")
+		}
+	}
+}
+
+func TestHotkeySaveFailureKeepsBindingAndReportsError(t *testing.T) {
+	s := screenState{root: t.TempDir(), ratio: 58, review: review.State{Help: true}}
+	s.relayout(140, 40)
+	dir, err := session.RepoDir(s.root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "layout.json"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.review.SetHotkey("v", "r"); err != nil {
+		t.Fatal(err)
+	}
+	s.dispatch(context.Background(), make(chan any, 1), make(chan struct{}))
+	if !strings.Contains(s.review.Notice, "could not save") || s.review.Binding("v") != "r" {
+		t.Fatal("save failure was hidden or discarded the active shortcut")
+	}
+}
+
+func TestConfiguredHotkeysSurviveCtrlQAndReopen(t *testing.T) {
+	for _, mode := range []string{"immediate", "review", "agent", "paste", "editing"} {
+		t.Run(mode, func(t *testing.T) {
+			s := screenState{root: t.TempDir(), ratio: 58, diffFocused: true}
+			s.relayout(140, 40)
+			var child bytes.Buffer
+			events, stop := make(chan any, 1), make(chan struct{})
+			// Configure Actions and Files through the editor. The immediate case
+			// receives Ctrl-Q in the same input chunk as the new assignments.
+			input := "?\rr\x1b[B\rz"
+			if mode == "immediate" {
+				s.handleInput([]byte(input+"\x11"), &child)
+			} else {
+				s.handleInput([]byte(input), &child)
+				s.dispatch(context.Background(), events, stop)
+				switch mode {
+				case "agent":
+					s.handleInput([]byte{7}, &child)
+				case "paste":
+					s.pastePending = true
+				case "editing":
+					s.handleInput([]byte("\r"), &child)
+				}
+				s.handleInput([]byte{0x11}, &child)
+			}
+			if !s.dispatch(context.Background(), events, stop) {
+				t.Fatal("Ctrl-Q did not quit")
+			}
+			want := map[string]string{"a": "r", "f": "z"}
+			// Verify the quit dispatch saved even the immediate edit before Run's
+			// deferred save, then exercise that save and a second quit/reopen.
+			for restart := 0; restart < 2; restart++ {
+				reopened := screenState{root: s.root, layout: ui.NewLayout(140, 40), diffFocused: true}
+				reopened.loadPreferences()
+				if !maps.Equal(reopened.review.Hotkeys, want) {
+					t.Fatalf("restart %d: hotkeys = %v, want %v", restart, reopened.review.Hotkeys, want)
+				}
+				if err := s.savePreferences(); err != nil {
+					t.Fatal(err)
+				}
+				reopened.handleInput([]byte("a"), &child)
+				if reopened.review.Menu {
+					t.Fatal("default shortcut was reactivated on restart")
+				}
+				reopened.handleInput([]byte("r\x11"), &child)
+				if !reopened.review.Menu || !reopened.dispatch(context.Background(), events, stop) {
+					t.Fatal("configured shortcut or Ctrl-Q stopped working after restart")
+				}
+				s = reopened
+			}
+			if child.Len() != 0 {
+				t.Fatal("configuration or Ctrl-Q input leaked to the agent")
+			}
+		})
+	}
+}

--- a/internal/app/hotkeys_test.go
+++ b/internal/app/hotkeys_test.go
@@ -105,7 +105,7 @@ func TestHotkeySaveFailureKeepsBindingAndReportsError(t *testing.T) {
 func TestConfiguredHotkeysSurviveCtrlQAndReopen(t *testing.T) {
 	for _, mode := range []string{"immediate", "review", "agent", "paste", "editing"} {
 		t.Run(mode, func(t *testing.T) {
-			s := screenState{root: t.TempDir(), ratio: 58, diffFocused: true}
+			s := &screenState{root: t.TempDir(), ratio: 58, diffFocused: true}
 			s.relayout(140, 40)
 			var child bytes.Buffer
 			events, stop := make(chan any, 1), make(chan struct{})
@@ -134,7 +134,7 @@ func TestConfiguredHotkeysSurviveCtrlQAndReopen(t *testing.T) {
 			// Verify the quit dispatch saved even the immediate edit before Run's
 			// deferred save, then exercise that save and a second quit/reopen.
 			for restart := 0; restart < 2; restart++ {
-				reopened := screenState{root: s.root, layout: ui.NewLayout(140, 40), diffFocused: true}
+				reopened := &screenState{root: s.root, layout: ui.NewLayout(140, 40), diffFocused: true}
 				reopened.loadPreferences()
 				if !maps.Equal(reopened.review.Hotkeys, want) {
 					t.Fatalf("restart %d: hotkeys = %v, want %v", restart, reopened.review.Hotkeys, want)

--- a/internal/app/mouse.go
+++ b/internal/app/mouse.go
@@ -42,6 +42,10 @@ func (s *screenState) mouse(sequence string) {
 		}
 		return
 	}
+	// Only keyboard input can assign a shortcut while capture is active.
+	if s.review.Help && s.review.EditingHotkey {
+		return
+	}
 	if button == 64 || button == 65 {
 		if x < s.layout.DiffX || x >= s.layout.DiffX+s.layout.DiffWidth || y < s.layout.DiffY || y >= s.layout.FooterY {
 			return
@@ -66,7 +70,7 @@ func (s *screenState) mouse(sequence string) {
 	}
 	s.mouseDragging = false
 	if y >= s.layout.FooterY {
-		key := ui.ControlKeyAt(s.layout.Width, x, y-s.layout.FooterY, true)
+		key := ui.ControlKeyAt(s.layout.Width, x, y-s.layout.FooterY, true, &s.review)
 		if key == "focus" {
 			if !s.exited {
 				s.diffFocused = false
@@ -86,6 +90,15 @@ func (s *screenState) mouse(sequence string) {
 		return
 	}
 	row := y - s.layout.DiffY
+	if s.review.Help {
+		if !s.review.EditingHotkey {
+			if index := ui.HelpActionAt(&s.review, s.layout.DiffHeight, row); index >= 0 {
+				s.review.HelpIndex = index
+				s.review.Key("enter", s.visibleLines())
+			}
+		}
+		return
+	}
 	if s.review.Menu {
 		count := max(1, s.layout.DiffHeight-4)
 		start := min(max(0, s.review.MenuIndex-count/2), max(0, len(review.Actions)-count))

--- a/internal/app/preferences.go
+++ b/internal/app/preferences.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"encoding/json"
+	"github.com/nccapo/stvena/internal/review"
 	"github.com/nccapo/stvena/internal/session"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 type preferences struct {
 	Ratio            int
 	Wrap, SideBySide bool
+	Hotkeys          map[string]string `json:",omitempty"`
 }
 
 func (s *screenState) loadPreferences() {
@@ -30,6 +32,12 @@ func (s *screenState) loadPreferences() {
 	}
 	s.review.Wrap = p.Wrap
 	s.review.SideBySide = p.SideBySide
+	s.review.Hotkeys = nil
+	if err := review.ValidateHotkeys(p.Hotkeys); err != nil {
+		s.review.Notice = "Invalid saved hotkeys; using defaults: " + err.Error()
+	} else {
+		s.review.Hotkeys = p.Hotkeys
+	}
 	s.relayout(s.layout.Width, s.layout.Height)
 }
 func (s *screenState) savePreferences() error {
@@ -37,5 +45,7 @@ func (s *screenState) savePreferences() error {
 	if err != nil {
 		return err
 	}
-	return session.AtomicJSON(filepath.Join(dir, "layout.json"), preferences{s.ratio, s.review.Wrap, s.review.SideBySide})
+	return session.AtomicJSON(filepath.Join(dir, "layout.json"), preferences{
+		Ratio: s.ratio, Wrap: s.review.Wrap, SideBySide: s.review.SideBySide, Hotkeys: s.review.Hotkeys,
+	})
 }

--- a/internal/app/workspace.go
+++ b/internal/app/workspace.go
@@ -80,7 +80,7 @@ func (s *screenState) updateSource() {
 	}
 }
 func (s *screenState) relayout(width, height int) {
-	s.layout = ui.NewLayoutOptions(width, height, s.ratio, s.fullscreen)
+	s.layout = ui.NewLayoutOptions(width, height, s.ratio, s.fullscreen, &s.review)
 }
 func (s *screenState) resizePTY(v *vt.Emulator, p *os.File) {
 	// Keep the agent's last usable size while review occupies the full screen.
@@ -111,6 +111,15 @@ func (s *screenState) setCheck(r checks.Result) {
 	s.review.CheckLines = strings.Split(r.Command+"\nSnapshot: "+r.Tree+"\n"+s.review.CheckStatus+fmt.Sprintf(" (exit %d)", r.ExitCode)+" · "+r.FinishedAt.Format(time.RFC3339)+"\n\n"+r.Output, "\n")
 }
 func (s *screenState) dispatch(ctx context.Context, events chan<- any, stop <-chan struct{}) bool {
+	if s.review.HotkeysDirty {
+		s.review.HotkeysDirty = false
+		s.relayout(s.layout.Width, s.layout.Height)
+		if err := s.savePreferences(); err != nil {
+			s.review.Notice = "Hotkeys active, but could not save: " + err.Error()
+		} else {
+			s.review.Notice = "Hotkeys saved for this repository"
+		}
+	}
 	r := s.review.Request
 	s.review.Request = ""
 	send := func(message string, err error) {

--- a/internal/review/hotkeys.go
+++ b/internal/review/hotkeys.go
@@ -1,0 +1,159 @@
+package review
+
+import (
+	"fmt"
+	"unicode"
+)
+
+// HotkeyActions describes the character shortcuts. Named navigation keys and
+// global terminal controls stay fixed so the editor is always accessible.
+var HotkeyActions = append([]Action{
+	{"a", "Actions menu", "Open all review actions"},
+	{"f", "File browser", "Return to the file list"},
+	{"n", "Next file", "Select the next file"},
+	{"p", "Previous file", "Select the previous file"},
+	{"d", "Page down / remove attachment", "Scroll half a page; remove the selected context attachment"},
+	{"u", "Page up", "Scroll half a page"},
+	{"g", "First file / line", "Jump to the beginning"},
+	{"G", "Last file / line", "Jump to the end"},
+	{"h", "Scroll left / parent folder", "Move left in code or the project tree"},
+	{"l", "Scroll right / enter folder", "Move right in code or the project tree"},
+	{"0", "Reset horizontal scroll", "Return to the start of the line"},
+	{"[", "Previous change", "Jump to the previous hunk or full-file change"},
+	{"]", "Next change", "Jump to the next hunk or full-file change"},
+	{"m", "Next text match", "Find the next search result"},
+	{"M", "Previous text match", "Find the previous search result"},
+	{"i", "Edit context request", "Edit your question for the agent"},
+	{"o", "Check problems", "Open source locations from check results"},
+}, Actions...)
+
+func (s *State) Binding(key string) string {
+	if custom := s.Hotkeys[key]; custom != "" {
+		return custom
+	}
+	return key
+}
+
+func KeyLabel(key string) string {
+	if key == " " {
+		return "Space"
+	}
+	return key
+}
+
+func validHotkey(key string) bool {
+	r := []rune(key)
+	return len(r) == 1 && (unicode.IsGraphic(r[0]) && !unicode.IsSpace(r[0]) && !unicode.IsMark(r[0]) || key == " ") && key != "?" && key != "j" && key != "k"
+}
+
+// ValidateHotkeys checks the effective map, including unchanged defaults.
+func ValidateHotkeys(bindings map[string]string) error {
+	known := make(map[string]bool, len(HotkeyActions))
+	used := make(map[string]string, len(HotkeyActions))
+	for _, action := range HotkeyActions {
+		known[action.Key] = true
+		key := action.Key
+		if custom, ok := bindings[key]; ok {
+			if !validHotkey(custom) {
+				return fmt.Errorf("Use one printable key; ?, j and k stay fixed")
+			}
+			key = custom
+		}
+		if other, ok := used[key]; ok {
+			return fmt.Errorf("%s is already assigned to %s", KeyLabel(key), other)
+		}
+		used[key] = action.Name
+	}
+	for key := range bindings {
+		if !known[key] {
+			return fmt.Errorf("unknown review shortcut %q", key)
+		}
+	}
+	return nil
+}
+
+func (s *State) SetHotkey(action, key string) error {
+	for _, other := range HotkeyActions {
+		if other.Key != action && s.Binding(other.Key) == key {
+			return fmt.Errorf("%s is already assigned to %s", KeyLabel(key), other.Name)
+		}
+	}
+	bindings := make(map[string]string, len(s.Hotkeys)+1)
+	for k, v := range s.Hotkeys {
+		bindings[k] = v
+	}
+	bindings[action] = key
+	if err := ValidateHotkeys(bindings); err != nil {
+		return err
+	}
+	if key == action {
+		delete(bindings, action)
+	}
+	s.Hotkeys = bindings
+	s.HotkeysDirty = true
+	return nil
+}
+
+// InputKey translates physical input once. Key remains the canonical action
+// entry point for mouse controls, menu selection and internal navigation.
+func (s *State) InputKey(key string, visible int) {
+	if !s.Help && !s.Searching && s.Prompt == "" && s.ConfirmAction == "" {
+		translated := key
+		for _, action := range HotkeyActions {
+			if s.Binding(action.Key) == key {
+				translated = action.Key
+				break
+			}
+			if action.Key == key {
+				translated = ""
+			}
+		}
+		key = translated
+	}
+	if key != "" {
+		s.Key(key, visible)
+	}
+}
+
+func (s *State) helpKey(key string) {
+	s.Notice = ""
+	s.HelpIndex = min(max(0, s.HelpIndex), len(HotkeyActions)-1)
+	if s.EditingHotkey {
+		if key == "esc" {
+			s.EditingHotkey = false
+			return
+		}
+		if err := s.SetHotkey(HotkeyActions[s.HelpIndex].Key, key); err != nil {
+			s.Notice = err.Error()
+			return
+		}
+		s.EditingHotkey = false
+		return
+	}
+	switch key {
+	case "?", "esc":
+		s.Help = false
+	case "up", "k":
+		s.HelpIndex = max(0, s.HelpIndex-1)
+	case "down", "j":
+		s.HelpIndex = min(len(HotkeyActions)-1, s.HelpIndex+1)
+	case "pageup":
+		s.HelpIndex = max(0, s.HelpIndex-10)
+	case "pagedown":
+		s.HelpIndex = min(len(HotkeyActions)-1, s.HelpIndex+10)
+	case "home":
+		s.HelpIndex = 0
+	case "end":
+		s.HelpIndex = len(HotkeyActions) - 1
+	case "enter":
+		s.EditingHotkey = true
+	case "backspace":
+		action := HotkeyActions[s.HelpIndex]
+		if err := s.SetHotkey(action.Key, action.Key); err != nil {
+			s.Notice = err.Error()
+		}
+	case "delete":
+		s.Hotkeys = nil
+		s.HotkeysDirty = true
+	}
+}

--- a/internal/review/hotkeys_test.go
+++ b/internal/review/hotkeys_test.go
@@ -1,0 +1,116 @@
+package review
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCustomHotkeysRouteInputOnlyOnce(t *testing.T) {
+	s := State{Hotkeys: map[string]string{"v": "w", "w": "v"}}
+	if err := ValidateHotkeys(s.Hotkeys); err != nil {
+		t.Fatal(err)
+	}
+	s.InputKey("w", 20)
+	if !s.FullFile || s.Wrap {
+		t.Fatal("swapped shortcut did not execute exactly one action")
+	}
+	s.InputKey("v", 20)
+	if !s.Wrap {
+		t.Fatal("other side of swap did not run")
+	}
+	s.Key("v", 20) // Mouse and menu actions remain canonical.
+	if s.FullFile {
+		t.Fatal("canonical action was remapped")
+	}
+	s = State{Hotkeys: map[string]string{"v": "r"}}
+	s.InputKey("v", 20)
+	if s.FullFile {
+		t.Fatal("old shortcut is still active")
+	}
+	s.InputKey("r", 20)
+	if !s.FullFile {
+		t.Fatal("new shortcut did not run")
+	}
+}
+
+func TestHotkeysPreserveTextEntryAndMenuActions(t *testing.T) {
+	s := State{Hotkeys: map[string]string{"v": "r"}, Searching: true}
+	s.InputKey("r", 20)
+	if s.Query != "r" || s.FullFile {
+		t.Fatal("file filter input was remapped")
+	}
+	s.Searching, s.Prompt = false, "Add comment"
+	s.InputKey("r", 20)
+	if s.Input != "r" || s.FullFile {
+		t.Fatal("prompt input was remapped")
+	}
+	s.Prompt, s.Menu = "", true
+	s.InputKey("r", 20)
+	if s.Menu || !s.FullFile {
+		t.Fatal("custom action menu shortcut failed")
+	}
+	s.FullFile, s.Menu = false, true
+	for i, action := range Actions {
+		if action.Key == "v" {
+			s.MenuIndex = i
+		}
+	}
+	s.InputKey("enter", 20)
+	if !s.FullFile {
+		t.Fatal("menu selection remapped its canonical action")
+	}
+}
+
+func TestHotkeyEditorConflictCancelAndReset(t *testing.T) {
+	s := State{Panel: "Context"}
+	s.InputKey("?", 20)
+	if !s.Help || s.Panel != "Context" {
+		t.Fatal("help did not open over existing panel")
+	}
+	s.InputKey("enter", 20)
+	s.InputKey("v", 20)
+	if !s.EditingHotkey || !strings.Contains(s.Notice, "already assigned to Diff / full file") || len(s.Hotkeys) != 0 {
+		t.Fatal("conflicting assignment was not rejected")
+	}
+	s.InputKey("esc", 20)
+	if !s.Help || s.EditingHotkey {
+		t.Fatal("Escape should cancel editing without closing help")
+	}
+	s.InputKey("enter", 20)
+	s.InputKey("r", 20)
+	if s.EditingHotkey || s.Binding("a") != "r" || !s.HotkeysDirty {
+		t.Fatal("hotkey was not updated")
+	}
+	s.InputKey("backspace", 20)
+	if s.Binding("a") != "a" {
+		t.Fatal("selected default was not restored")
+	}
+	s.InputKey("enter", 20)
+	s.InputKey("r", 20)
+	s.InputKey("delete", 20)
+	if len(s.Hotkeys) != 0 {
+		t.Fatal("reset all did not clear overrides")
+	}
+	s.InputKey("?", 20)
+	if s.Help || s.Panel != "Context" {
+		t.Fatal("closing help did not return to the existing view")
+	}
+}
+
+func TestHotkeyValidation(t *testing.T) {
+	for _, key := range []string{"?", "j", "k", "esc", "enter", "", "ab", "\x07", "\n", "\u200b", "\u0301"} {
+		if err := ValidateHotkeys(map[string]string{"v": key}); err == nil {
+			t.Errorf("accepted reserved or invalid key %q", key)
+		}
+	}
+	if err := ValidateHotkeys(map[string]string{"unknown": "r"}); err == nil {
+		t.Fatal("accepted unknown action")
+	}
+	if err := ValidateHotkeys(map[string]string{"v": "界"}); err != nil {
+		t.Fatal(err)
+	}
+	s := State{Hotkeys: map[string]string{"v": "r", "w": "v"}}
+	if err := s.SetHotkey("v", "v"); err == nil || s.Binding("v") != "r" {
+		t.Fatal("reset silently overwrote another shortcut")
+	}
+}

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -21,6 +21,9 @@ type State struct {
 	Scope                             int
 	Query                             string
 	Searching, PatchFocused, Help     bool
+	Hotkeys                           map[string]string
+	HelpIndex                         int
+	EditingHotkey, HotkeysDirty       bool
 	Browser, FullFile                 bool
 	Content                           diffview.Content
 	ContentKey                        string
@@ -199,6 +202,11 @@ func (s *State) Clamp(visible int) {
 
 // Key accepts a decoded key or a Unicode character; no keys mutate Git/files.
 func (s *State) Key(key string, visible int) {
+	if key == "?" && !s.Help && !s.Searching && s.Prompt == "" && s.ConfirmAction == "" {
+		s.Help, s.EditingHotkey = true, false
+		s.Notice = ""
+		return
+	}
 	if s.Selecting && !s.Menu && s.Prompt == "" && s.Panel == "" && !s.Help && !s.Searching {
 		switch key {
 		case "f", "esc", "backspace", "n", "p", "v", "s", "view-file", "view-diff":
@@ -240,9 +248,7 @@ func (s *State) Key(key string, visible int) {
 		return
 	}
 	if s.Help {
-		if key == "?" || key == "esc" || key == "enter" {
-			s.Help = false
-		}
+		s.helpKey(key)
 		return
 	}
 	if s.Panel != "" && s.Prompt == "" && s.ConfirmAction == "" && !s.Menu {
@@ -279,8 +285,6 @@ func (s *State) Key(key string, visible int) {
 			s.Key("v", visible)
 		}
 		return
-	case "?":
-		s.Help = true
 	case "f":
 		s.TargetLine = 0
 		s.Browser, s.PatchFocused = true, false

--- a/internal/ui/hotkeys.go
+++ b/internal/ui/hotkeys.go
@@ -1,0 +1,60 @@
+package ui
+
+import (
+	"fmt"
+
+	"github.com/nccapo/stvena/internal/review"
+)
+
+// HelpListWindow is shared by rendering and mouse hit testing.
+func HelpListWindow(s *review.State, height int) (int, int) {
+	count := min(len(review.HotkeyActions), max(0, height-4))
+	start := min(max(0, s.HelpIndex-count/2), len(review.HotkeyActions)-count)
+	return start, count
+}
+
+func HelpActionAt(s *review.State, height, row int) int {
+	start, count := HelpListWindow(s, height)
+	if row >= 3 && row < 3+count {
+		return start + row - 3
+	}
+	return -1
+}
+
+func renderHelp(s *review.State, width, height int) []string {
+	rows := make([]string, height)
+	for i := range rows {
+		rows[i] = reviewRow("", width)
+	}
+	put := func(row int, text string) {
+		if row >= 0 && row < height {
+			rows[row] = reviewRow(" "+text, width)
+		}
+	}
+	put(0, headerBG+bold+"REVIEW CONTROLS · Configure hotkeys")
+	put(1, "↑/↓: select · Enter / click: change · Esc: back")
+	put(2, muted+"Backspace: reset key · Delete: reset all · * custom")
+	start, count := HelpListWindow(s, height)
+	for i := start; i < start+count; i++ {
+		action := review.HotkeyActions[i]
+		marker, style := "  ", ""
+		if i == s.HelpIndex {
+			marker, style = "› ", focusedBG+bold
+		}
+		custom := " "
+		if s.Binding(action.Key) != action.Key {
+			custom = "*"
+		}
+		put(3+i-start, style+fmt.Sprintf("%s%-5s %s %s", marker, review.KeyLabel(s.Binding(action.Key)), custom, action.Name)+reset)
+	}
+	footer := "Changes save automatically for this repository"
+	if s.EditingHotkey {
+		action := review.HotkeyActions[s.HelpIndex]
+		footer = "Press a printable key for " + action.Name + " · Esc: cancel"
+	}
+	if s.Notice != "" {
+		footer = s.Notice
+	}
+	put(height-1, cyan+footer)
+	return rows
+}

--- a/internal/ui/hotkeys_test.go
+++ b/internal/ui/hotkeys_test.go
@@ -1,0 +1,75 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/nccapo/stvena/internal/review"
+)
+
+func TestHotkeyHelpScrollsAndHitTestsVisibleActions(t *testing.T) {
+	for _, height := range []int{1, 5, 12, 30} {
+		for _, index := range []int{0, 25, len(review.HotkeyActions) - 1} {
+			s := review.State{Help: true, HelpIndex: index, Hotkeys: map[string]string{"a": "r"}}
+			rows := renderReview(&s, 60, height, true)
+			if len(rows) != height {
+				t.Fatal("help exceeded the pane height")
+			}
+			selected := false
+			for row, text := range rows {
+				if ansi.StringWidth(text) != 60 {
+					t.Fatal("help exceeded the pane width")
+				}
+				if action := HelpActionAt(&s, height, row); action >= 0 {
+					if !strings.Contains(ansi.Strip(text), review.HotkeyActions[action].Name) {
+						t.Fatal("click target did not match rendered action")
+					}
+					selected = selected || action == index
+				}
+			}
+			if height >= 5 && !selected {
+				t.Fatal("selected action scrolled out of view")
+			}
+		}
+	}
+}
+
+func TestCustomHotkeyLabelsKeepCanonicalClickActions(t *testing.T) {
+	s := review.State{Browser: true, Hotkeys: map[string]string{"N": "r", "b": "界", "v": "w", "w": "v"}}
+	footer := ansi.Strip(renderReview(&s, 100, 20, true)[19])
+	x := strings.Index(footer, "r: next unreviewed")
+	if x < 0 || ReviewControlKeyAt(&s, 100, 20, x, 19) != "N" {
+		t.Fatal("custom footer label and canonical click action diverged")
+	}
+	s.Panel = "Context preview"
+	if !strings.Contains(panelControlBar(&s), "界: Paste to agent") || PanelControlKeyAt(&s, 100, 20, 1, 19) != "b" {
+		t.Fatal("custom panel control did not retain its click action")
+	}
+	s.Panel, s.Menu = "", true
+	if !strings.Contains(strings.Join(renderOverlay(&s, 100, 45), "\n"), "w     Diff / full file") {
+		t.Fatal("Actions menu did not show the custom shortcut")
+	}
+	for _, width := range []int{35, 65, 100, 140} {
+		rows := controlRows(width, true, &s)
+		layout := NewLayoutOptions(width, 40, 58, false, &s)
+		if layout.FooterHeight != len(rows) {
+			t.Fatal("layout did not account for custom footer widths")
+		}
+		found := false
+		for y, row := range rows {
+			plain := ansi.Strip(row)
+			for x := 0; x < width; x++ {
+				if ControlKeyAt(width, x, y, true, &s) == "b" {
+					found = true
+					if !strings.Contains(plain, "界: Add to agent") {
+						t.Fatal("footer hit testing did not use custom label widths")
+					}
+				}
+			}
+		}
+		if !found {
+			t.Fatal("custom footer control has no click target")
+		}
+	}
+}

--- a/internal/ui/overlays.go
+++ b/internal/ui/overlays.go
@@ -39,10 +39,7 @@ func renderOverlay(s *review.State, width, height int) []string {
 		start := min(max(0, s.MenuIndex-count/2), max(0, len(review.Actions)-count))
 		for i := start; i < min(len(review.Actions), start+count); i++ {
 			a := review.Actions[i]
-			key := a.Key
-			if key == " " {
-				key = "Space"
-			}
+			key := review.KeyLabel(s.Binding(a.Key))
 			style := ""
 			marker := "  "
 			if i == s.MenuIndex {

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -36,10 +36,10 @@ type Layout struct {
 
 func NewLayout(width, height int) Layout { return NewLayoutOptions(width, height, 58, false) }
 
-func NewLayoutOptions(width, height, ratio int, fullscreen bool) Layout {
+func NewLayoutOptions(width, height, ratio int, fullscreen bool, state ...*review.State) Layout {
 	width, height = max(1, width), max(1, height)
 	l := Layout{Width: width, Height: height, LeftY: 1}
-	l.FooterHeight = min(len(controlRows(width, false)), max(0, height-2))
+	l.FooterHeight = min(len(controlRows(width, false, state...)), max(0, height-2))
 	l.FooterY = height - l.FooterHeight
 	contentHeight := max(1, l.FooterY-1)
 	if fullscreen {
@@ -117,7 +117,7 @@ func Render(w io.Writer, terminal *vt.Emulator, state *review.State, layout Layo
 		rows[targetY] = overlay(rows[targetY], layout.DiffX, row, layout.Width)
 	}
 
-	controls := controlRows(layout.Width, diffFocused)
+	controls := controlRows(layout.Width, diffFocused, state)
 	if !diffFocused && state.AgentDraft {
 		controls[0] = cyan + bold + " Type request · Enter: send · Ctrl-G: Switch panes" + reset
 	}
@@ -218,8 +218,8 @@ func overlay(base string, x int, content string, width int) string {
 
 // Keep the review shortcuts visible across the full terminal width, wrapping
 // whole shortcuts onto additional footer rows on narrower terminals.
-func controlRows(width int, diffFocused bool) []string {
-	controls := footerControls()
+func controlRows(width int, diffFocused bool, state ...*review.State) []string {
+	controls := footerControls(state...)
 	var rows []string
 	row := " "
 	for i, control := range controls {
@@ -231,7 +231,8 @@ func controlRows(width int, diffFocused bool) []string {
 			rows = append(rows, row)
 			row, gap = " ", ""
 		}
-		key, label, _ := strings.Cut(control, ":")
+		separator := strings.LastIndex(control, ":")
+		key, label := control[:separator], control[separator+1:]
 		style := cyan + bold
 		if !diffFocused && i > 0 && !strings.HasPrefix(control, "Ctrl-") {
 			style = muted
@@ -241,13 +242,20 @@ func controlRows(width int, diffFocused bool) []string {
 	return append(rows, row)
 }
 
-func footerControls() []string {
-	return []string{"Ctrl-G: Switch panes", "Ctrl-]: New agent", "Ctrl-N: Next agent", "Ctrl-P: Previous agent", "Ctrl-W: Close agent", "3: Files", "1: Changes", "2: Workspace", "T: Checks", "B: Context", "b: Add to agent", "a: Actions", "F: Expand", "Ctrl-Q: quit all"}
+func footerControls(state ...*review.State) []string {
+	controls := []string{"Ctrl-G: Switch panes", "Ctrl-]: New agent", "Ctrl-N: Next agent", "Ctrl-P: Previous agent", "Ctrl-W: Close agent", "3: Files", "1: Changes", "2: Workspace", "T: Checks", "B: Context", "b: Add to agent", "a: Actions", "F: Expand", "?: Hotkeys", "Ctrl-Q: quit all"}
+	if len(state) > 0 && state[0] != nil {
+		for i, control := range controls {
+			key, label, _ := strings.Cut(control, ":")
+			controls[i] = review.KeyLabel(state[0].Binding(key)) + ":" + label
+		}
+	}
+	return controls
 }
-func ControlKeyAt(width, x, y int, _ bool) string {
+func ControlKeyAt(width, x, y int, _ bool, state ...*review.State) string {
 	row, column := 0, 1
-	keys := []string{"focus", "new-agent", "next-agent", "previous-agent", "close-agent", "3", "1", "2", "T", "B", "b", "a", "F", "quit-app"}
-	for i, label := range footerControls() {
+	keys := []string{"focus", "new-agent", "next-agent", "previous-agent", "close-agent", "3", "1", "2", "T", "B", "b", "a", "F", "?", "quit-app"}
+	for i, label := range footerControls(state...) {
 		gap := 0
 		if column > 1 {
 			gap = 2

--- a/internal/ui/review.go
+++ b/internal/ui/review.go
@@ -24,6 +24,9 @@ func renderReview(s *review.State, width, height int, focused bool) []string {
 	if height <= 0 {
 		return nil
 	}
+	if s.Help {
+		return renderHelp(s, width, height)
+	}
 	if WelcomeVisible(s) {
 		return renderWelcome(s, width, height, focused)
 	}
@@ -49,146 +52,138 @@ func renderReview(s *review.State, width, height int, focused bool) []string {
 	} else {
 		add(bg + bold + fmt.Sprintf(" %d %s  %s+%d -%d", s.Snapshot.FileCount, noun, approx, s.Snapshot.Added, s.Snapshot.Deleted) + reset + bg + "  " + safeText(s.Snapshot.Branch))
 	}
-	if s.Help {
-		for _, line := range []string{
-			" REVIEW CONTROLS", " Ctrl-G     switch panes (agent / workspace)", " Ctrl-]     choose command for a new agent", " Ctrl-N/P   next / previous agent terminal", " Ctrl-W     close and stop current agent", " Ctrl-Q     quit stvena and stop all agents", " j/k ↑/↓    select file / scroll patch", " Enter      open selected file", " f          open file browser", " v          toggle diff / full file", " Backspace  focus file list", " n / p      next / previous file", " N          next unreviewed file", " Tab        all → staged → unstaged → new", " /          filter file paths", " Esc        cancel filter / return to list", " d/u PgDn/Up  half-page scroll", " g/G        first / last file or line", " [ / ]      previous / next hunk", " h/l ←/→    horizontal scroll", " 0          reset horizontal scroll", " Space      mark / unmark reviewed", " Drag       select source lines with the mouse", " V          start / clear code selection", " b          paste selected code into agent draft", " x / B      collect code / open context tray", " 3          browse all project files", " T then o   checks / navigable problems", " ? / Esc    close help", "", " Review marks clear when content changes.", " Incomplete/conflicted files cannot be marked.", " Counts sum staged + unstaged + untracked.", " ~ means a preview/count is incomplete.", " a          open all review actions", " F          expand review", " 1 / 2      session / workspace", " P          pin / resume live", " S / A      stage file / hunk (confirmation)",
-		} {
+	scope := "all"
+	if s.Scope != 0 {
+		scope = string(review.Scopes[s.Scope])
+	}
+	filter := ""
+	if s.Query != "" || s.Searching {
+		filter = "  /" + safeText(s.Query)
+		if s.Searching {
+			filter += "▏"
+		}
+	}
+	source := s.Snapshot.Label
+	if source == "" {
+		source = "Workspace"
+	}
+	if s.Pinned {
+		source += " · Pinned"
+		pinnedVersion := s.PinnedVersion
+		if pinnedVersion == "" {
+			pinnedVersion = s.Snapshot.Version
+		}
+		if s.Latest.Version != pinnedVersion {
+			source += " (updates available)"
+		}
+	}
+	if !s.Pinned {
+		source += " · Live"
+	}
+	if s.Source != "session" && s.Source != "project" {
+		source += " · " + scope
+	}
+	if s.Checkpoint != nil {
+		freshness := "live unchanged"
+		if s.CheckpointNewer() {
+			freshness = "NEW LIVE"
+		}
+		if s.Latest.Tree == "" && !s.CheckpointNewer() {
+			freshness = "checking live…"
+		}
+		add(cyan + fmt.Sprintf(" Pinned · %s · %d comments · %d selections", freshness, len(s.CheckpointComments()), len(s.Attachments)))
+	} else if s.Source == "project" {
+		add(cyan + " " + source + filter)
+	} else {
+		add(cyan + " " + source + fmt.Sprintf(" · %d/%d reviewed", s.ReviewedCount(), len(s.Snapshot.Files)) + filter)
+	}
+	fileRows, patchRows := ReviewSize(height, s.FileListCount())
+	if s.Browser {
+		fileRows = min(len(s.Indices), max(0, height-3))
+	}
+	if s.Source == "project" {
+		for _, row := range projectTreeRows(s, width, height) {
+			add(row)
+		}
+		fileRows = 0
+	}
+	start := min(max(0, s.Selected-fileRows/2), max(0, len(s.Indices)-fileRows))
+	for i := start; i < start+fileRows; i++ {
+		f := s.Snapshot.Files[s.Indices[i]]
+		marker, style := "  ", ""
+		if i == s.Selected {
+			marker, style = "› ", focusedBG+bold
+		}
+		check := " "
+		if s.Reviewed(f) {
+			check = "✓"
+		} else if _, ok := s.History[f.Key()]; ok {
+			check = "↻"
+		}
+		name := safeText(path.Base(f.Path))
+		directory := path.Dir(f.Path)
+		detail := ""
+		if directory != "." {
+			detail = "  " + safeText(directory)
+		}
+		if f.OldPath != "" {
+			detail = "  ← " + safeText(f.OldPath)
+		}
+		status := map[string]string{"M": "Modified", "A": "Added", "D": "Deleted", "R": "Renamed", "C": "Copied", "U": "Conflict", "?": "New", "??": "New"}[f.Status]
+		if status == "" {
+			status = f.Status
+		}
+		if s.Source != "session" && f.Scope != diffview.Session {
+			if status != "" {
+				status += " · "
+			}
+			status += string(f.Scope)
+		}
+		stats := " " + status + "  " + fileStats(f) + " "
+		badge, badgeColor := f.Status, muted
+		switch badge {
+		case "M":
+			badgeColor = yellow
+		case "A", "?", "??":
+			badge, badgeColor = "A", green
+		case "D", "U":
+			badgeColor = red
+		case "R", "C":
+			badgeColor = cyan
+		}
+		left := style + marker + badgeColor + bold + fitANSI(safeText(badge), 1) + reset + style + " " + check + " " + bold + name + reset + style + muted + detail
+		// Keep the filename visible before secondary directory and status details.
+		if width >= 50 && s.Source != "project" {
+			add(fitANSI(left, max(0, width-ansiWidth(stats))) + muted + stats)
+		} else {
+			add(left)
+		}
+	}
+	if f := s.Current(); f != nil && !s.Browser {
+		add(bg + viewTabs(s) + muted + "  " + safeText(f.Path))
+		if height >= 7 {
+			if s.Selecting {
+				add(cyan + selectionSummary(s))
+			} else if s.FullFile {
+				add(muted + " LINE  Δ │ " + safeText(s.Content.Source))
+			} else {
+				add(muted + "   OLD   NEW │ PATCH")
+			}
+		}
+		for _, line := range codeRows(s, width, patchRows) {
 			add(line)
 		}
-	} else {
-		scope := "all"
-		if s.Scope != 0 {
-			scope = string(review.Scopes[s.Scope])
-		}
-		filter := ""
-		if s.Query != "" || s.Searching {
-			filter = "  /" + safeText(s.Query)
-			if s.Searching {
-				filter += "▏"
+	} else if s.Snapshot.Err == nil && len(s.Indices) == 0 {
+		if s.Snapshot.FileCount == 0 {
+			if s.Source == "session" {
+				add(dim + " No changes in this session yet.")
+				add(muted + " Existing edits are in Workspace (2).")
+			} else {
+				add(dim + " Working tree is clean.")
 			}
-		}
-		source := s.Snapshot.Label
-		if source == "" {
-			source = "Workspace"
-		}
-		if s.Pinned {
-			source += " · Pinned"
-			pinnedVersion := s.PinnedVersion
-			if pinnedVersion == "" {
-				pinnedVersion = s.Snapshot.Version
-			}
-			if s.Latest.Version != pinnedVersion {
-				source += " (updates available)"
-			}
-		}
-		if !s.Pinned {
-			source += " · Live"
-		}
-		if s.Source != "session" && s.Source != "project" {
-			source += " · " + scope
-		}
-		if s.Checkpoint != nil {
-			freshness := "live unchanged"
-			if s.CheckpointNewer() {
-				freshness = "NEW LIVE"
-			}
-			if s.Latest.Tree == "" && !s.CheckpointNewer() {
-				freshness = "checking live…"
-			}
-			add(cyan + fmt.Sprintf(" Pinned · %s · %d comments · %d selections", freshness, len(s.CheckpointComments()), len(s.Attachments)))
-		} else if s.Source == "project" {
-			add(cyan + " " + source + filter)
+			add(cyan + " Ctrl-G: Switch panes · a: Actions")
 		} else {
-			add(cyan + " " + source + fmt.Sprintf(" · %d/%d reviewed", s.ReviewedCount(), len(s.Snapshot.Files)) + filter)
-		}
-		fileRows, patchRows := ReviewSize(height, s.FileListCount())
-		if s.Browser {
-			fileRows = min(len(s.Indices), max(0, height-3))
-		}
-		if s.Source == "project" {
-			for _, row := range projectTreeRows(s, width, height) {
-				add(row)
-			}
-			fileRows = 0
-		}
-		start := min(max(0, s.Selected-fileRows/2), max(0, len(s.Indices)-fileRows))
-		for i := start; i < start+fileRows; i++ {
-			f := s.Snapshot.Files[s.Indices[i]]
-			marker, style := "  ", ""
-			if i == s.Selected {
-				marker, style = "› ", focusedBG+bold
-			}
-			check := " "
-			if s.Reviewed(f) {
-				check = "✓"
-			} else if _, ok := s.History[f.Key()]; ok {
-				check = "↻"
-			}
-			name := safeText(path.Base(f.Path))
-			directory := path.Dir(f.Path)
-			detail := ""
-			if directory != "." {
-				detail = "  " + safeText(directory)
-			}
-			if f.OldPath != "" {
-				detail = "  ← " + safeText(f.OldPath)
-			}
-			status := map[string]string{"M": "Modified", "A": "Added", "D": "Deleted", "R": "Renamed", "C": "Copied", "U": "Conflict", "?": "New", "??": "New"}[f.Status]
-			if status == "" {
-				status = f.Status
-			}
-			if s.Source != "session" && f.Scope != diffview.Session {
-				if status != "" {
-					status += " · "
-				}
-				status += string(f.Scope)
-			}
-			stats := " " + status + "  " + fileStats(f) + " "
-			badge, badgeColor := f.Status, muted
-			switch badge {
-			case "M":
-				badgeColor = yellow
-			case "A", "?", "??":
-				badge, badgeColor = "A", green
-			case "D", "U":
-				badgeColor = red
-			case "R", "C":
-				badgeColor = cyan
-			}
-			left := style + marker + badgeColor + bold + fitANSI(safeText(badge), 1) + reset + style + " " + check + " " + bold + name + reset + style + muted + detail
-			// Keep the filename visible before secondary directory and status details.
-			if width >= 50 && s.Source != "project" {
-				add(fitANSI(left, max(0, width-ansiWidth(stats))) + muted + stats)
-			} else {
-				add(left)
-			}
-		}
-		if f := s.Current(); f != nil && !s.Browser {
-			add(bg + viewTabs(s) + muted + "  " + safeText(f.Path))
-			if height >= 7 {
-				if s.Selecting {
-					add(cyan + selectionSummary(s))
-				} else if s.FullFile {
-					add(muted + " LINE  Δ │ " + safeText(s.Content.Source))
-				} else {
-					add(muted + "   OLD   NEW │ PATCH")
-				}
-			}
-			for _, line := range codeRows(s, width, patchRows) {
-				add(line)
-			}
-		} else if s.Snapshot.Err == nil && len(s.Indices) == 0 {
-			if s.Snapshot.FileCount == 0 {
-				if s.Source == "session" {
-					add(dim + " No changes in this session yet.")
-					add(muted + " Existing edits are in Workspace (2).")
-				} else {
-					add(dim + " Working tree is clean.")
-				}
-				add(cyan + " Ctrl-G: Switch panes · a: Actions")
-			} else {
-				add(dim + " No files match this view. Esc clears filter.")
-			}
+			add(dim + " No files match this view. Esc clears filter.")
 		}
 	}
 	footer := reviewFooter(s)

--- a/internal/ui/review_controls.go
+++ b/internal/ui/review_controls.go
@@ -12,10 +12,20 @@ type reviewControl struct{ key, label string }
 func reviewControls(s *review.State) []reviewControl {
 	controls := baseReviewControls(s)
 	if s.Checkpoint != nil {
-		return append([]reviewControl{{"Z", "Z: Finish checkpoint"}, {"P", "P: Resume live"}}, controls...)
-	}
-	if s.Pinned && !s.Selecting {
+		controls = append([]reviewControl{{"Z", "Z: Finish checkpoint"}, {"P", "P: Resume live"}}, controls...)
+	} else if s.Pinned && !s.Selecting {
 		controls = append([]reviewControl{{"P", "P: Resume live"}}, controls...)
+	}
+	return boundControls(s, controls)
+}
+
+func boundControls(s *review.State, controls []reviewControl) []reviewControl {
+	for i := range controls {
+		c := &controls[i]
+		if key := s.Binding(c.key); key != c.key {
+			_, label, _ := strings.Cut(c.label, ":")
+			c.label = review.KeyLabel(key) + ":" + label
+		}
 	}
 	return controls
 }
@@ -137,6 +147,10 @@ func selectionSummary(s *review.State) string {
 }
 
 func panelControls(s *review.State) []reviewControl {
+	return boundControls(s, basePanelControls(s))
+}
+
+func basePanelControls(s *review.State) []reviewControl {
 	switch s.Panel {
 	case "Checkpoint draft":
 		return []reviewControl{{"b", "b: Paste / export"}, {"y", "y: Copy"}, {"i", "i: Request"}, {"esc", "Esc: Review"}}


### PR DESCRIPTION
Review shortcuts were hard-coded and the `?` screen only listed controls. Users can now press `?` or click `?: Hotkeys`, select an action, and assign a printable key with conflict checks and reset controls. Menus and clickable toolbars display the configured bindings.

Bindings apply immediately and save in the repository's layout preferences. Ctrl-Q followed by reopening the same repository preserves them, including when the final edit and quit arrive in one input chunk. Global Ctrl shortcuts and basic navigation stay fixed; text entry and agent input retain their existing behavior.

Validation:

- `go test -race ./...`, `go vet ./...`, and `go build ./...` passed during implementation.
- `go test -race ./internal/app` passed after adding the final Ctrl-Q/reopen regression coverage.
- Tests cover remapping, conflicts, resets, prompt and agent input, mouse controls, narrow/wide rendering, save failures, and repeated quit/reopen cycles.
- Formatting and staged diff checks passed.
