### PR TITLE
Share shortcuts across projects and open on accessible configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ stvena sessions
 stvena review --session ID
 ```
 
+**Shortcuts use Ctrl on both macOS and Linux.** Command keys normally belong
+to the terminal application. Optional Command aliases require a terminal that
+forwards them; see [terminal shortcut setup](docs/usage.md#command-keys-in-your-terminal).
+
 **Multiple agent terminals:** Ctrl-] opens a chooser: **c** starts Codex, **l**
 starts Claude Code, and **Enter** repeats your original command with its arguments.
 Run Codex and Claude side by side; Ctrl-N / Ctrl-P switch between them. Background
@@ -111,7 +115,8 @@ but direct selection paste is supported for Codex and Claude Code.
 
 ## A typical workflow
 
-1. Start `stvena` in your project and give the agent a task.
+1. Start `stvena` in your project. Press **Enter** to configure shortcuts, or
+   **Esc** to type your task in the agent.
 2. Press **Ctrl-G** to focus review. Open a changed file, or press **3** to browse
    the project. Press **v** to switch between a diff and the full file.
 3. Drag over code and press **b** to paste it into the agent's input. Add your
@@ -124,6 +129,7 @@ but direct selection paste is supported for Codex and Claude Code.
 
 | Key | Action |
 | --- | --- |
+| **F6** | Focus bottom panel; arrows select, Enter activates, Esc returns |
 | **Ctrl-G** | Switch between agent and review |
 | **Ctrl-]** | Open another agent terminal |
 | **Ctrl-N / Ctrl-P** | Next / previous agent terminal |
@@ -140,6 +146,11 @@ but direct selection paste is supported for Codex and Claude Code.
 | **t / T** | Run a check / inspect results |
 | **a / ?** | Actions menu / keyboard help |
 
+Stvena opens with the bottom panel focused and **Configuration** selected.
+Press **Enter** to change shortcuts, or **Esc** to start typing in the agent.
+Use arrows to select any other footer action. For a Ctrl-G conflict, change
+**Switch panes** to **Ctrl-O**; Ctrl-G then reaches the agent. Settings apply
+across projects. **?** opens Configuration in review; **F6** can refocus the footer.
 Review shortcuts apply when review has focus. **Ctrl-C** keeps the agent's
 native interrupt behavior. Review remains open after the agent exits; **q**
 closes it. See the [complete user guide](docs/usage.md) for comments, hunk staging,
@@ -160,8 +171,10 @@ Stvena does not require its own API key or account. It launches the agent CLI
 you already use with your environment and credentials. Your chosen agent's
 network access and data handling still apply.
 
-- Review metadata, comments, snippets, draft requests, preferences, and check
+- Review metadata, comments, snippets, draft requests, layout preferences, and check
   output are stored under your OS cache directory in `stvena/<repository hash>`.
+- Custom shortcuts are shared across projects in your OS user configuration
+  directory at `stvena/hotkeys.json`.
 - Captured code is retained in local Git objects under `refs/stvena/sessions/*`
   and `refs/stvena/reviews/*`. Use normal branch pushes; a mirror push can also
   publish these private refs.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,7 +16,12 @@ stvena claude
 stvena -- codex --model YOUR_MODEL
 ```
 
-Paste your prompt into the agent normally. **Ctrl-G** switches panes. Click a file
+The shortcuts below use **Ctrl** on both macOS and Linux. Command keys belong
+to the terminal application unless it is explicitly configured to forward them;
+see [Command keys in your terminal](#command-keys-in-your-terminal).
+
+Stvena starts with **Configuration** selected in the bottom panel. Press
+**Enter** to adjust shortcuts, or **Esc** to focus the agent and paste your prompt. **Ctrl-G** switches panes. Click a file
 or select it with arrows and Enter. **v** switches between changed lines and the
 whole file. **a** opens the Actions menu; the common controls stay at the bottom.
 You can also click the **Changes** and **Full file** tabs. File rows put names
@@ -305,23 +310,48 @@ There are no discard, restore, commit, push or branch-editing actions.
 
 ## Controls
 
-Press **?** in review, or click **?: Hotkeys** in the footer, to configure review
-shortcuts. Select an action with **↑/↓** (or **j/k**) and press **Enter**, or click
-its row, then press a replacement printable key. Uppercase and lowercase keys
-are distinct. Conflicting assignments are rejected; move the existing binding
-first to free its key. **Esc** cancels an edit or closes the controls screen.
-**Backspace** restores the selected shortcut; **Delete** restores all defaults.
-Changes apply immediately and save with this repository's layout preferences.
+The bottom panel has focus when Stvena opens, with **Configuration** already
+selected. Press **Enter** to configure shortcuts immediately, or **Esc** to start
+typing in the agent (or return to review in standalone mode). No Ctrl combination
+or function key is needed to reach Configuration on startup.
+
+Use **Left/Right** to select a footer control, **Up/Down** to move between wrapped
+rows, and **Enter** to activate it. **Esc** returns to the pane. **Down** at the
+end of a review file list also enters the panel; **Up** from its first row
+returns to the pane. Ordinary arrow keys in the agent pane remain available to
+its editor and history after leaving the footer. **F6** remains an optional way
+to refocus the panel; keyboards with media controls may require **Fn-F6**.
+
+Select **?: Configuration** in the panel to edit shortcuts. It opens on
+**Switch panes**, so a Ctrl-G conflict never prevents configuration. For example,
+press **Enter**, then **Ctrl-O** to change pane switching from Ctrl-G to Ctrl-O.
+Ctrl-G is then passed through to the agent. **?** in review also opens Configuration.
+
+Select another action with **↑/↓** (or **j/k**) and press **Enter**, or click its
+row. Global actions (switch panes, new/next/previous/close agent, quit all) accept
+Ctrl combinations. Review actions accept one printable key; uppercase and
+lowercase are distinct. Conflicts are rejected. Ctrl-C, Ctrl-D/U, the control
+bytes used for text-entry/navigation keys, and F6 cannot be assigned as global
+actions. **Esc** cancels an edit or closes Configuration. **Backspace** restores
+the selected shortcut; **Delete** restores all defaults.
+
+Changes apply immediately and save for all projects. Every newly opened Stvena
+window loads the same shortcuts. Layout settings remain specific to each project.
+Existing repository shortcuts migrate automatically when you open the first
+project with custom bindings; shared settings take precedence after that,
+including when you reset to defaults.
 
 The controls screen, Actions menu and clickable toolbars show your configured
 keys. A shortcut retains its context-dependent behavior (for example, **d**
 scrolls code but removes an attachment in Context). **?**, **j/k**, named
-navigation keys (arrows, Enter, Esc, Tab, Backspace, etc.) and global **Ctrl**
-shortcuts stay fixed. Text entry and input to the agent are unaffected.
+navigation keys (arrows, Enter, Esc, Tab, Backspace, etc.) and **F6** stay fixed.
+Configured global shortcuts are intercepted in either pane. Freed shortcuts and
+ordinary text entry pass through to the agent.
 The table below lists defaults.
 
 | Key | Action |
 | --- | --- |
+| F6 | Focus the bottom panel; arrows navigate, Enter activates, Esc returns |
 | Ctrl-G | Switch panes (agent / workspace), preserving the open file and selection |
 | Ctrl-] | Choose Codex, Claude Code, or the launch command for a new terminal |
 | Ctrl-N / Ctrl-P | Switch to the next / previous agent terminal |
@@ -355,14 +385,50 @@ The table below lists defaults.
 | q | Quit after all agents exit, or quit standalone review |
 
 Review shortcuts are dimmed while the agent has focus. Agent input passes through
-unchanged except for the reserved Ctrl-G, Ctrl-], Ctrl-N, Ctrl-P, Ctrl-W and Ctrl-Q keys.
+unchanged except for F6, configured global shortcuts (by default Ctrl-G, Ctrl-],
+Ctrl-N, Ctrl-P, Ctrl-W and Ctrl-Q), and their active Command aliases. Footer
+navigation consumes arrows and Enter only while the panel has focus.
 Shortcuts inside a bracketed paste are treated as literal pasted text.
+
+### Command keys in your terminal
+
+Stvena cannot override keyboard shortcuts handled by the terminal application.
+For example, Apple Terminal uses **Cmd-G** for Find Next and **Cmd-W** to close
+its tab ([Apple's shortcut reference](https://support.apple.com/guide/terminal/keyboard-shortcuts-trmlshtcts/mac)).
+Use **Ctrl-G** to switch Stvena panes and **Ctrl-]** to open its agent chooser,
+or click the footer controls. Stvena displays your configured shortcuts.
+
+Optional Command aliases are recognized when a terminal forwards them using the
+[Kitty keyboard protocol's CSI-u encoding](https://sw.kovidgoyal.net/kitty/keyboard-protocol/).
+If your terminal supports custom Command bindings that send escape sequences,
+you can configure these aliases there while the corresponding Ctrl chord is
+assigned in Stvena. Reassigning a Ctrl chord also releases its Command alias. This requires terminal-side support;
+changing a Stvena binding or enabling a keyboard protocol cannot take over a
+terminal application's menu shortcut.
+
+| Command key | Sequence to send (`ESC` is the escape byte) |
+| --- | --- |
+| Cmd-G | `ESC[103;9u` |
+| Cmd-] | `ESC[93;9u` |
+| Cmd-N | `ESC[110;9u` |
+| Cmd-P | `ESC[112;9u` |
+| Cmd-W | `ESC[119;9u` |
+| Cmd-Q | `ESC[113;9u` |
+
+**Ctrl-C** remains the agent's native interrupt. Ordinary review letter keys
+continue to work without a modifier.
 
 ## Local storage and limits
 
 Session metadata, pinned checkpoints, comments, review marks, context attachments, draft requests,
-preferences and the latest check result
+layout preferences and the latest check result
 are stored under the OS user cache directory in `stvena/<repository hash>`.
+Shared shortcuts are stored separately at `stvena/hotkeys.json` under the OS
+user configuration directory: `~/Library/Application Support` on macOS, and
+`$XDG_CONFIG_HOME` (or `~/.config`) on Linux. Closing an unedited window does not
+overwrite shortcut changes made in another project. Reopen an already running
+window to load changes made elsewhere.
+
 Private `refs/stvena/sessions/*` and `refs/stvena/reviews/*` retain Git objects
 needed for snapshots and saved review references. Snapshot capture uses a
 separate temporary index, preserving your normal index and branch. Snapshots

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -66,7 +66,7 @@ func Run(args []string) error {
 		return nil
 	}
 	if len(args) == 1 && (args[0] == "--help" || args[0] == "-h") {
-		fmt.Fprintln(os.Stdout, "Usage: stvena [--] [command [args...]]\n       stvena review [--session ID]\n       stvena sessions\n\nDefault command: codex. Ctrl-G switches panes (agent/workspace), preserving the open file; a opens Actions.\nCtrl-] chooses Codex, Claude Code, or the launch command for a new terminal. Ctrl-N / Ctrl-P switch agent terminals.\nCtrl-W closes the current agent terminal and stops its command.\nCtrl-Q closes stvena and stops all running commands. Ctrl-C interrupts the command.\nReview stays open after commands exit. q closes review once all agents finish.\nRun inside the repository you want to review.")
+		fmt.Fprintln(os.Stdout, "Usage: stvena [--] [command [args...]]\n       stvena review [--session ID]\n       stvena sessions\n\nDefault command: codex. The bottom panel starts focused on Configuration.\nArrows select, Enter activates, Esc returns to the agent or review. F6 can refocus the panel.\nSelect Configuration to change global or review shortcuts for all projects.\nCtrl-G switches panes (agent/workspace), preserving the open file; a opens Actions.\nCtrl-] chooses Codex, Claude Code, or the launch command for a new terminal. Ctrl-N / Ctrl-P switch agent terminals.\nCtrl-W closes the current agent terminal and stops its command.\nCtrl-Q closes stvena and stops all running commands. Ctrl-C interrupts the command.\nReview stays open after commands exit. q closes review once all agents finish.\nRun inside the repository you want to review.")
 		return nil
 	}
 	if len(args) == 1 && args[0] == "sessions" {
@@ -231,6 +231,15 @@ func Run(args []string) error {
 		state.review.AgentStatus = "Review"
 		state.relayout(width, height)
 	}
+	// Start on a usable control before any potentially conflicting shortcut is
+	// needed. Esc gives the agent (or standalone review) normal keyboard input.
+	state.review.FooterFocused = true
+	for i, control := range ui.FooterControls {
+		if control.Action == "?" {
+			state.review.FooterIndex = i
+			break
+		}
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer func() {
 		cancel()
@@ -357,7 +366,7 @@ func Run(args []string) error {
 				lastWelcomeFrame = time.Now()
 				dirty = true
 			}
-			if len(state.pending) > 0 && time.Since(state.lastInput) > 50*time.Millisecond {
+			if (len(state.pending) > 0 || len(state.keyboardPending) > 0) && time.Since(state.lastInput) > 50*time.Millisecond {
 				state.decodeInput(true)
 				if state.dispatch(ctx, events, stop) {
 					return nil
@@ -367,7 +376,7 @@ func Run(args []string) error {
 				dirty = true
 			}
 			if dirty {
-				if wantMouse := state.diffFocused || state.agentPicker != nil; mouseEnabled != wantMouse {
+				if wantMouse := state.diffFocused || state.review.FooterFocused || state.agentPicker != nil; mouseEnabled != wantMouse {
 					mouseEnabled = wantMouse
 					if mouseEnabled {
 						fmt.Fprint(os.Stdout, "\x1b[?1002h\x1b[?1006h")
@@ -403,6 +412,8 @@ type screenState struct {
 	layout                              ui.Layout
 	review                              review.State
 	diffFocused                         bool
+	keyboardPending                     []byte
+	keyboardPasting                     bool
 	pending                             []byte
 	lastInput                           time.Time
 	contentID                           int
@@ -434,11 +445,11 @@ func (s *screenState) visibleLines() int {
 	_, lines := ui.ReviewSize(s.layout.DiffHeight, s.review.FileListCount())
 	return lines
 }
-func (s *screenState) handleInput(data []byte, child io.Writer) {
+func (s *screenState) handleLegacyInput(data []byte, child io.Writer) {
 	if s.pastePending {
 		// Closing the app must also work while a handoff waits for the CLI.
 		for _, b := range data {
-			if b == 0x11 {
+			if s.review.GlobalAction(review.ControlKey(b)) == "Ctrl-Q" {
 				s.review.Request = "quit-app"
 				s.pending, s.pasteInput = nil, nil
 				return
@@ -485,7 +496,19 @@ func (s *screenState) handleInput(data []byte, child io.Writer) {
 			}
 			continue
 		}
-		if b == 0x11 {
+		// A plain Escape leaves the footer before the following text is routed.
+		// Keep that text in this input batch so rapid Esc + typing loses no key.
+		if s.review.FooterFocused && len(s.pending) == 1 && s.pending[0] == 0x1b && b != '[' && b != 'O' {
+			s.pending = nil
+			s.footerKey("esc")
+		}
+		inputKey := review.ControlKey(b)
+		if s.review.EditingGlobalHotkey() && inputKey != "" && b != '\r' && b != '\n' && b != '\t' && b != 0x08 {
+			s.review.InputKey(inputKey, s.visibleLines())
+			continue
+		}
+		action := s.review.GlobalAction(inputKey)
+		if action == "Ctrl-Q" {
 			s.review.Request = "quit-app"
 			s.pending, s.pasteInput = nil, nil
 			return
@@ -497,35 +520,23 @@ func (s *screenState) handleInput(data []byte, child io.Writer) {
 			child = s.agentInput
 			continue
 		}
-		if b == 0x1d || b == 0x0e || b == 0x10 || b == 0x17 {
+		if action == "Ctrl-]" || action == "Ctrl-N" || action == "Ctrl-P" || action == "Ctrl-W" {
 			// Flush preceding text to its original terminal before switching.
 			if len(forward) > 0 {
 				_, _ = child.Write(forward)
 				forward = forward[:0]
 			}
-			s.agentShortcut(b)
+			s.agentShortcut(review.ControlByte(action))
 			if s.agentInput != nil {
 				child = s.agentInput
 			}
 			continue
 		}
-		if b == 0x07 { // Switch focus without discarding the open file or selection.
-			s.pending = nil
-			s.mouseDragging = false
-			s.diffFocused = !s.diffFocused
-			if s.exited {
-				s.diffFocused = true
-			}
-			if !s.diffFocused && s.fullscreen {
-				s.fullscreen = false
-				s.relayout(s.layout.Width, s.layout.Height)
-			}
-			if s.diffFocused && !s.review.PatchFocused {
-				s.review.Browser = true
-			}
+		if action == "Ctrl-G" {
+			s.switchPane()
 			continue
 		}
-		if !s.diffFocused {
+		if !s.diffFocused && !s.review.FooterFocused {
 			if b == '\r' || b == '\n' {
 				if s.review.AgentDraft {
 					s.review.ClearSelection()
@@ -553,6 +564,9 @@ func (s *screenState) handleInput(data []byte, child io.Writer) {
 }
 
 func (s *screenState) decodeInput(flush bool) {
+	if flush {
+		s.flushKeyboardInput()
+	}
 	for len(s.pending) > 0 {
 		key, consumed := "", 1
 		switch s.pending[0] {
@@ -607,8 +621,12 @@ func (s *screenState) decodeInput(flush bool) {
 		s.pending = s.pending[consumed:]
 		if key != "" {
 			s.mouseDragging = false
-			if s.agentPicker != nil {
+			if s.review.FooterFocused {
+				s.footerKey(key)
+			} else if s.agentPicker != nil {
 				s.agentPickerKey(key)
+			} else if key == "down" && s.atFileListEnd() {
+				s.review.FooterFocused, s.review.FooterIndex = true, 0
 			} else {
 				s.review.InputKey(key, s.visibleLines())
 			}

--- a/internal/app/footer.go
+++ b/internal/app/footer.go
@@ -1,0 +1,102 @@
+package app
+
+import (
+	"github.com/nccapo/stvena/internal/review"
+	"github.com/nccapo/stvena/internal/ui"
+)
+
+func (s *screenState) toggleFooter() {
+	s.review.FooterFocused = !s.review.FooterFocused
+	s.review.EditingHotkey = false
+	s.agentPicker = nil
+	s.pending = nil
+	s.mouseDragging = false
+}
+
+func (s *screenState) footerKey(key string) {
+	switch key {
+	case "esc":
+		s.review.FooterFocused = false
+	case "enter":
+		index := min(max(0, s.review.FooterIndex), len(ui.FooterControls)-1)
+		s.activateFooter(ui.FooterControls[index].Action)
+	default:
+		index := ui.FooterMove(s.layout.Width, s.review.FooterIndex, key, &s.review)
+		if index < 0 {
+			s.review.FooterFocused = false
+		} else {
+			s.review.FooterIndex = index
+		}
+	}
+}
+
+// Mouse and keyboard activation share canonical actions, never remapped input.
+func (s *screenState) activateFooter(key string) {
+	if key == "" {
+		return
+	}
+	if key == "footer" {
+		s.toggleFooter()
+		return
+	}
+	s.review.FooterFocused = false
+	switch key {
+	case "focus":
+		s.switchPane()
+	case "new-agent", "next-agent", "previous-agent", "close-agent":
+		s.agentShortcut(map[string]byte{"new-agent": 0x1d, "next-agent": 0x0e, "previous-agent": 0x10, "close-agent": 0x17}[key])
+	case "quit-app":
+		s.review.Request = key
+	default:
+		s.diffFocused = true
+		if key == "?" {
+			s.review.Help = true
+			s.review.EditingHotkey = false
+			s.review.Notice = ""
+			// Start with pane switching: this is the recovery route for conflicts.
+			for i, action := range review.HotkeyActions {
+				if action.Key == "Ctrl-G" {
+					s.review.HelpIndex = i
+					break
+				}
+			}
+			return
+		}
+		if s.review.Prompt != "" || s.review.ConfirmAction != "" || s.review.Searching {
+			s.review.Notice = "Finish or cancel text entry before choosing this action"
+			return
+		}
+		// A toolbar action operates on the underlying review even with Help open.
+		s.review.Help = false
+		s.review.Key(key, s.visibleLines())
+	}
+}
+
+func (s *screenState) switchPane() {
+	s.review.FooterFocused = false
+	s.pending = nil
+	s.mouseDragging = false
+	s.diffFocused = !s.diffFocused
+	if s.exited {
+		s.diffFocused = true
+	}
+	if !s.diffFocused && s.fullscreen {
+		s.fullscreen = false
+		s.relayout(s.layout.Width, s.layout.Height)
+	}
+	if s.diffFocused && !s.review.PatchFocused {
+		s.review.Browser = true
+	}
+}
+
+func (s *screenState) atFileListEnd() bool {
+	r := &s.review
+	if !r.Browser || r.Help || r.Menu || r.Searching || r.Prompt != "" || r.ConfirmAction != "" || r.Panel != "" {
+		return false
+	}
+	index := r.Selected
+	if r.Source == "project" {
+		index = r.TreeIndex
+	}
+	return index >= r.FileListCount()-1
+}

--- a/internal/app/footer_test.go
+++ b/internal/app/footer_test.go
@@ -1,0 +1,180 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/nccapo/stvena/internal/diffview"
+	"github.com/nccapo/stvena/internal/review"
+	"github.com/nccapo/stvena/internal/ui"
+)
+
+func TestFooterRecoveryConfiguresGlobalShortcutAcrossProjects(t *testing.T) {
+	isolateHotkeys(t)
+	s := terminalState(t)
+	s.root = t.TempDir()
+	// No Ctrl-G or mouse: F6, arrows to Configuration, Enter, Enter, Ctrl-O.
+	input := "\x1b[17~"
+	for _, control := range ui.FooterControls {
+		if control.Action == "?" {
+			break
+		}
+		input += "\x1b[C"
+	}
+	input += "\r\r\x0f"
+	for _, b := range []byte(input) {
+		s.handleInput([]byte{b}, s.agentInput)
+	}
+	if !s.review.Help || s.review.EditingHotkey || s.review.Binding("Ctrl-G") != "Ctrl-O" || s.review.FooterFocused {
+		t.Fatalf("keyboard recovery did not configure pane shortcut: %s", s.review.Notice)
+	}
+	s.dispatch(context.Background(), make(chan any, 1), make(chan struct{}))
+	reopened := screenState{root: t.TempDir()}
+	reopened.loadPreferences()
+	if reopened.review.Binding("Ctrl-G") != "Ctrl-O" {
+		t.Fatal("global shortcut did not reach another project")
+	}
+	s.handleInput([]byte("\x0f\x07agent"), s.agentInput)
+	if s.diffFocused || s.agentInput.(*bytes.Buffer).String() != "\x07agent" {
+		t.Fatal("new binding failed or old Ctrl-G was not released to the agent")
+	}
+}
+
+func TestFooterPreservesAgentArrowsAndRestoresFocus(t *testing.T) {
+	s := terminalState(t)
+	s.handleInput([]byte("\x1b[A\x1b[B\x1b[C\x1b[D"), s.agentInput)
+	if s.review.FooterFocused || s.agentInput.(*bytes.Buffer).String() != "\x1b[A\x1b[B\x1b[C\x1b[D" {
+		t.Fatal("agent arrows were intercepted")
+	}
+	before := s.agentInput.(*bytes.Buffer).String()
+	s.handleInput([]byte("\x1b[17~\x1b[C\x1b[B\x1b[A\x1b"), s.agentInput)
+	s.decodeInput(true)
+	if s.review.FooterFocused || s.diffFocused || s.agentInput.(*bytes.Buffer).String() != before {
+		t.Fatal("footer navigation leaked or changed pane")
+	}
+	s.diffFocused = true
+	s.review.Browser = true
+	s.review.Update(diffview.Snapshot{Files: []diffview.File{{Path: "one"}}})
+	s.handleInput([]byte("\x1b[B"), s.agentInput)
+	if !s.review.FooterFocused {
+		t.Fatal("Down at end of file list did not reach footer")
+	}
+	s.handleInput([]byte("\x1b[A"), s.agentInput)
+	if s.review.FooterFocused || !s.diffFocused {
+		t.Fatal("Up from first footer row did not return to review")
+	}
+}
+
+func TestFooterConfigurationOverSearchPreservesQuery(t *testing.T) {
+	s := terminalState(t)
+	s.review.Searching, s.review.Query = true, "unfinished"
+	s.activateFooter("?")
+	s.handleInput([]byte("\r\x0f\x1b"), s.agentInput)
+	s.decodeInput(true)
+	if s.review.Help || !s.review.Searching || s.review.Query != "unfinished" || s.review.Binding("Ctrl-G") != "Ctrl-O" {
+		t.Fatal("configuration changed search text or could not capture Ctrl key")
+	}
+}
+
+func TestGlobalQuitRemappingAndSwaps(t *testing.T) {
+	for _, pending := range []bool{false, true} {
+		s := terminalState(t)
+		s.pastePending = pending
+		if err := s.review.SetHotkey("Ctrl-Q", "Ctrl-X"); err != nil {
+			t.Fatal(err)
+		}
+		s.handleInput([]byte{0x11}, s.agentInput)
+		if s.review.Request != "" {
+			t.Fatal("old quit key remained active")
+		}
+		s.handleInput([]byte{0x18}, s.agentInput)
+		if s.review.Request != "quit-app" || len(s.pasteInput) != 0 {
+			t.Fatal("new quit key failed during handoff")
+		}
+	}
+	s := terminalState(t)
+	s.review.Hotkeys = map[string]string{"Ctrl-G": "Ctrl-N", "Ctrl-N": "Ctrl-G"}
+	if err := review.ValidateHotkeys(s.review.Hotkeys); err != nil {
+		t.Fatal(err)
+	}
+	s.handleInput([]byte{0x0e}, s.agentInput)
+	if !s.diffFocused {
+		t.Fatal("swapped global binding was translated twice")
+	}
+}
+
+func TestFooterAndCustomGlobalKeysInsidePasteStayLiteral(t *testing.T) {
+	s := terminalState(t)
+	if err := s.review.SetHotkey("Ctrl-G", "Ctrl-O"); err != nil {
+		t.Fatal(err)
+	}
+	payload := ansi.BracketedPasteStart + "text\x0f\x1b[17~\x1b[C\r" + ansi.BracketedPasteEnd
+	for _, b := range []byte(payload) {
+		s.handleInput([]byte{b}, s.agentInput)
+	}
+	if s.review.FooterFocused || s.diffFocused || s.agentInput.(*bytes.Buffer).String() != payload {
+		t.Fatal("paste executed footer or custom global shortcut")
+	}
+}
+
+func TestFooterConfigurationMouseAndActionsFromAgent(t *testing.T) {
+	s := terminalState(t)
+	s.activateFooter("?")
+	if !s.diffFocused || !s.review.Help {
+		t.Fatal("Configuration did not focus review")
+	}
+	s.activateFooter("T")
+	if s.review.Help || s.review.Panel != "Checks" {
+		t.Fatal("toolbar action remained trapped in Configuration")
+	}
+	s.activateFooter("focus")
+	if s.diffFocused {
+		t.Fatal("pane control did not return to agent")
+	}
+	s.activateFooter("1")
+	if !s.diffFocused || s.review.Request != "1" {
+		t.Fatal("Changes action did not focus review")
+	}
+	// A released Cmd-G must not reclaim the reassigned Ctrl-G action either.
+	if err := s.review.SetHotkey("Ctrl-G", "Ctrl-O"); err != nil {
+		t.Fatal(err)
+	}
+	s.diffFocused = false
+	s.handleInput([]byte("\x1b[103;9u"), s.agentInput)
+	if s.diffFocused || !strings.Contains(s.agentInput.(*bytes.Buffer).String(), "\x1b[103;9u") {
+		t.Fatal("old Command alias reactivated pane switching")
+	}
+}
+
+func TestClickingPaneLeavesFooterNavigation(t *testing.T) {
+	s := terminalState(t)
+	s.toggleFooter()
+	s.mouse(fmt.Sprintf("<0;%d;%dM", s.layout.DiffX+2, s.layout.DiffY+1))
+	if s.review.FooterFocused || !s.diffFocused {
+		t.Fatal("clicking review left keyboard focus on footer")
+	}
+}
+
+func TestLeavingFooterWithEscapePreservesImmediateAgentInput(t *testing.T) {
+	for _, text := range []string{"startup-input", "目录"} {
+		for _, fragmented := range []bool{false, true} {
+			s := terminalState(t)
+			s.review.FooterFocused = true
+			input := []byte("\x1b" + text)
+			if fragmented {
+				for _, b := range input {
+					s.handleInput([]byte{b}, s.agentInput)
+				}
+			} else {
+				s.handleInput(input, s.agentInput)
+			}
+			if s.review.FooterFocused || s.diffFocused || s.agentInput.(*bytes.Buffer).String() != text {
+				t.Fatalf("text=%q fragmented=%t: lost or rerouted input %q", text, fragmented, s.agentInput.(*bytes.Buffer).String())
+			}
+		}
+	}
+}

--- a/internal/app/hotkeys_test.go
+++ b/internal/app/hotkeys_test.go
@@ -15,7 +15,17 @@ import (
 	"github.com/nccapo/stvena/internal/ui"
 )
 
+func isolateHotkeys(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	previous := preferencesConfigDir
+	preferencesConfigDir = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { preferencesConfigDir = previous })
+	return filepath.Join(dir, "stvena", "hotkeys.json")
+}
+
 func TestConfigureHotkeyWithMouseAndPersist(t *testing.T) {
+	isolateHotkeys(t)
 	s := screenState{root: t.TempDir(), ratio: 58, diffFocused: true}
 	s.relayout(140, 40)
 	var child bytes.Buffer
@@ -33,6 +43,7 @@ func TestConfigureHotkeyWithMouseAndPersist(t *testing.T) {
 	if !clicked || !s.review.Help {
 		t.Fatal("clicking ? did not open hotkey configuration")
 	}
+	s.review.HelpIndex = 0 // Exercise the review-key section after opening Configuration.
 	s.mouse(fmt.Sprintf("<0;%d;%dM", s.layout.DiffX+2, s.layout.DiffY+4))
 	if !s.review.EditingHotkey {
 		t.Fatal("clicking an action did not start editing")
@@ -63,6 +74,7 @@ func TestConfigureHotkeyWithMouseAndPersist(t *testing.T) {
 }
 
 func TestHotkeyPreferencesRejectConflictsAndReadOldLayout(t *testing.T) {
+	isolateHotkeys(t)
 	s := screenState{root: t.TempDir(), layout: ui.NewLayout(140, 40)}
 	dir, err := session.RepoDir(s.root)
 	if err != nil {
@@ -84,13 +96,10 @@ func TestHotkeyPreferencesRejectConflictsAndReadOldLayout(t *testing.T) {
 }
 
 func TestHotkeySaveFailureKeepsBindingAndReportsError(t *testing.T) {
+	path := isolateHotkeys(t)
 	s := screenState{root: t.TempDir(), ratio: 58, review: review.State{Help: true}}
 	s.relayout(140, 40)
-	dir, err := session.RepoDir(s.root)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Mkdir(filepath.Join(dir, "layout.json"), 0700); err != nil {
+	if err := os.MkdirAll(path, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.review.SetHotkey("v", "r"); err != nil {
@@ -105,6 +114,7 @@ func TestHotkeySaveFailureKeepsBindingAndReportsError(t *testing.T) {
 func TestConfiguredHotkeysSurviveCtrlQAndReopen(t *testing.T) {
 	for _, mode := range []string{"immediate", "review", "agent", "paste", "editing"} {
 		t.Run(mode, func(t *testing.T) {
+			isolateHotkeys(t)
 			s := &screenState{root: t.TempDir(), ratio: 58, diffFocused: true}
 			s.relayout(140, 40)
 			var child bytes.Buffer
@@ -156,5 +166,102 @@ func TestConfiguredHotkeysSurviveCtrlQAndReopen(t *testing.T) {
 				t.Fatal("configuration or Ctrl-Q input leaked to the agent")
 			}
 		})
+	}
+}
+
+func TestHotkeysSharedAcrossProjectsWithoutSharingLayout(t *testing.T) {
+	path := isolateHotkeys(t)
+	first := screenState{root: t.TempDir(), ratio: 65}
+	first.review.Wrap = true
+	first.review.SideBySide = true
+	if err := first.review.SetHotkey("a", "r"); err != nil {
+		t.Fatal(err)
+	}
+	if err := first.savePreferences(); err != nil {
+		t.Fatal(err)
+	}
+	second := screenState{root: t.TempDir(), ratio: 58}
+	second.loadPreferences() // This repository has never had a layout file.
+	if second.review.Binding("a") != "r" || second.ratio != 58 || second.review.Wrap || second.review.SideBySide {
+		t.Fatalf("shared hotkeys or independent layout failed: binding=%q ratio=%d wrap=%t sideBySide=%t", second.review.Binding("a"), second.ratio, second.review.Wrap, second.review.SideBySide)
+	}
+	if err := second.review.SetHotkey("a", "z"); err != nil {
+		t.Fatal(err)
+	}
+	if err := second.savePreferences(); err != nil {
+		t.Fatal(err)
+	}
+	// An older window closing must not overwrite a more recent customization.
+	if err := first.savePreferences(); err != nil {
+		t.Fatal(err)
+	}
+	reopened := screenState{root: first.root}
+	reopened.loadPreferences()
+	if reopened.review.Binding("a") != "z" || reopened.ratio != 65 || !reopened.review.Wrap || !reopened.review.SideBySide {
+		t.Fatal("stale window overwrote global settings or lost project layout")
+	}
+	if info, err := os.Stat(path); err != nil || info.Mode().Perm() != 0600 {
+		t.Fatalf("global config permissions: %v, %v", info, err)
+	}
+}
+
+func TestLegacyHotkeysMigrateOnceAndResetGlobally(t *testing.T) {
+	isolateHotkeys(t)
+	first := screenState{root: t.TempDir()}
+	second := screenState{root: t.TempDir()}
+	for _, s := range []*screenState{&first, &second} {
+		dir, err := session.RepoDir(s.root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "layout.json"), []byte(`{"Ratio":65,"Hotkeys":{"a":"r"}}`), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	first.loadPreferences()
+	fresh := screenState{root: t.TempDir()}
+	fresh.loadPreferences()
+	if first.review.Binding("a") != "r" || fresh.review.Binding("a") != "r" {
+		t.Fatal("legacy customization was not migrated for other projects")
+	}
+	first.review.Help = true
+	first.review.InputKey("delete", 20)
+	if err := first.savePreferences(); err != nil {
+		t.Fatal(err)
+	}
+	second.loadPreferences()
+	if second.review.Binding("a") != "a" || len(second.review.Hotkeys) != 0 {
+		t.Fatal("old project settings resurrected a globally reset binding")
+	}
+}
+
+func TestInvalidGlobalHotkeysKeepLayoutAndDoNotFallBackToLegacy(t *testing.T) {
+	path := isolateHotkeys(t)
+	s := screenState{root: t.TempDir()}
+	dir, err := session.RepoDir(s.root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "layout.json"), []byte(`{"Ratio":65,"Wrap":true,"Hotkeys":{"a":"r"}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	for _, data := range []string{`{"Hotkeys":{"v":"w"}}`, `{"Hotkeys":`} {
+		if err := os.WriteFile(path, []byte(data), 0600); err != nil {
+			t.Fatal(err)
+		}
+		s.loadPreferences()
+		if len(s.review.Hotkeys) != 0 || s.ratio != 65 || !s.review.Wrap || !strings.Contains(s.review.Notice, "Invalid saved hotkeys") {
+			t.Fatalf("invalid global config mishandled: %s", s.review.Notice)
+		}
+		if err := s.savePreferences(); err != nil {
+			t.Fatal(err)
+		}
+		saved, err := os.ReadFile(path)
+		if err != nil || string(saved) != data {
+			t.Fatal("unedited invalid config overwritten")
+		}
 	}
 }

--- a/internal/app/keyboard.go
+++ b/internal/app/keyboard.go
@@ -1,0 +1,158 @@
+package app
+
+import (
+	"bytes"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/nccapo/stvena/internal/review"
+)
+
+// handleInput recognizes optional Command aliases forwarded by the terminal.
+// Ctrl remains the default: a terminal app may consume Command keys itself.
+// Buffer escape sequences across reads, but keep normal input/pastes batched.
+func (s *screenState) handleInput(data []byte, child io.Writer) {
+	data = append(s.keyboardPending, data...)
+	s.keyboardPending = nil
+	decoded := make([]byte, 0, len(data))
+	flush := func() {
+		s.handleLegacyInput(decoded, child)
+		decoded = decoded[:0]
+		if s.agentInput != nil {
+			child = s.agentInput
+		}
+	}
+	for len(data) > 0 {
+		if data[0] != 0x1b {
+			decoded = append(decoded, data[0])
+			data = data[1:]
+			continue
+		}
+		end := 1
+		if len(data) > 1 && data[1] == '[' {
+			end = 2
+			for end < len(data) && data[end] >= 0x20 && data[end] <= 0x3f {
+				end++
+			}
+		}
+		if end == len(data) && len(data) < 128 {
+			s.keyboardPending = append([]byte(nil), data...)
+			s.lastInput = time.Now()
+			break
+		}
+		if end < len(data) && end > 1 {
+			end++
+		}
+		sequence := data[:end]
+		switch string(sequence) {
+		case ansi.BracketedPasteStart:
+			s.keyboardPasting = true
+		case ansi.BracketedPasteEnd:
+			s.keyboardPasting = false
+		default:
+			if !s.keyboardPasting {
+				if string(sequence) == "\x1b[17~" {
+					flush()
+					if s.review.Request == "quit-app" {
+						return
+					}
+					if s.review.Request == "paste-agent" || s.review.Request == "paste-context" || s.review.Request == "paste-checkpoint" {
+						s.pasteInput = append(s.pasteInput, data...)
+						return
+					}
+					if s.pastePending {
+						s.pasteInput = append(s.pasteInput, sequence...)
+					} else {
+						s.toggleFooter()
+					}
+					data = data[end:]
+					continue
+				}
+				if key, ok := commandShortcut(sequence); ok {
+					flush()
+					if s.review.Request == "quit-app" {
+						return
+					}
+					if s.review.Request == "paste-agent" || s.review.Request == "paste-context" || s.review.Request == "paste-checkpoint" {
+						s.pasteInput = append(s.pasteInput, data...)
+						return
+					}
+					// Command aliases follow the configured Ctrl chord. They must
+					// not resurrect an old binding after the user frees that key.
+					if key != 0 && s.review.GlobalAction(review.ControlKey(key)) == "" && !s.review.EditingGlobalHotkey() {
+						decoded = append(decoded, sequence...)
+						data = data[end:]
+						continue
+					}
+					if key != 0 {
+						decoded = append(decoded, key)
+					}
+					data = data[end:]
+					continue
+				}
+			}
+		}
+		decoded = append(decoded, sequence...)
+		data = data[end:]
+	}
+	s.handleLegacyInput(decoded, child)
+}
+
+func (s *screenState) flushKeyboardInput() {
+	data := s.keyboardPending
+	s.keyboardPending = nil
+	if len(data) > 0 {
+		s.handleLegacyInput(data, s.agentInput)
+	}
+}
+
+// commandShortcut maps only the six global shortcuts. Unknown sequences and
+// additional modifiers retain their original bytes; key releases are consumed.
+func commandShortcut(sequence []byte) (byte, bool) {
+	if !bytes.HasPrefix(sequence, []byte("\x1b[")) || sequence[len(sequence)-1] != 'u' {
+		return 0, false
+	}
+	params := strings.Split(string(sequence[2:len(sequence)-1]), ";")
+	if len(params) != 2 {
+		return 0, false
+	}
+	code, _, _ := strings.Cut(params[0], ":")
+	key, err := strconv.Atoi(code)
+	if err != nil {
+		return 0, false
+	}
+	mod, event, _ := strings.Cut(params[1], ":")
+	modifier, err := strconv.Atoi(mod)
+	// Ignore Caps Lock and Num Lock, but no extra held modifiers.
+	if err != nil || modifier < 1 || (modifier-1)&^192 != 8 {
+		return 0, false
+	}
+	var control byte
+	switch key {
+	case 'g':
+		control = 0x07
+	case ']':
+		control = 0x1d
+	case 'n':
+		control = 0x0e
+	case 'p':
+		control = 0x10
+	case 'w':
+		control = 0x17
+	case 'q':
+		control = 0x11
+	default:
+		return 0, false
+	}
+	switch event {
+	case "", "1":
+		return control, true
+	case "2", "3": // Do not repeat pane switches, terminal creation or closes.
+		return 0, true
+	default:
+		return 0, false
+	}
+}

--- a/internal/app/keyboard_test.go
+++ b/internal/app/keyboard_test.go
@@ -1,0 +1,133 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestCommandShortcutsRouteAcrossAgentsAndPanes(t *testing.T) {
+	for _, fragmented := range []bool{false, true} {
+		t.Run(fmt.Sprint(fragmented), func(t *testing.T) {
+			s := terminalState(t)
+			first := s.activeAgent()
+			input := "first\x1b[93;9u\rsecond\x1b[112;9uback\x1b[110;9unext\x1b[103;9u"
+			if fragmented {
+				for _, b := range []byte(input) {
+					s.handleInput([]byte{b}, s.agentInput)
+				}
+			} else {
+				s.handleInput([]byte(input), s.agentInput)
+			}
+			if len(s.agents) != 2 || s.activeAgentIndex != 1 || !s.diffFocused {
+				t.Fatal("Command new/previous/next/focus shortcuts failed")
+			}
+			if first.input.(*bytes.Buffer).String() != "firstback" || s.agentInput.(*bytes.Buffer).String() != "secondnext" {
+				t.Fatal("Command sequences leaked or input reached the wrong terminal")
+			}
+			s.handleInput([]byte("\x1b[119;9uafter"), s.agentInput)
+			if len(s.agents) != 1 || s.activeAgent() != first || s.diffFocused || first.input.(*bytes.Buffer).String() != "firstbackafter" {
+				t.Fatal("Command-W failed from review")
+			}
+		})
+	}
+}
+
+func TestCommandQuitWorksDuringEditingAndHandoffAndSavesGlobally(t *testing.T) {
+	for _, mode := range []string{"agent", "review", "paste", "editing", "picker"} {
+		t.Run(mode, func(t *testing.T) {
+			isolateHotkeys(t)
+			s := terminalState(t)
+			s.root = t.TempDir()
+			switch mode {
+			case "review":
+				s.diffFocused = true
+			case "paste":
+				s.pastePending = true
+			case "editing":
+				s.diffFocused, s.review.Help, s.review.EditingHotkey = true, true, true
+			case "picker":
+				s.agentShortcut(0x1d)
+			}
+			if err := s.review.SetHotkey("a", "r"); err != nil {
+				t.Fatal(err)
+			}
+			for _, b := range []byte("\x1b[113;9u") {
+				s.handleInput([]byte{b}, s.agentInput)
+			}
+			if !s.dispatch(context.Background(), make(chan any, 1), make(chan struct{})) {
+				t.Fatal("Command-Q did not quit")
+			}
+			if s.agentInput.(*bytes.Buffer).Len() != 0 || len(s.pasteInput) != 0 {
+				t.Fatal("quit leaked input")
+			}
+			other := screenState{root: t.TempDir()}
+			other.loadPreferences()
+			if other.review.Binding("a") != "r" {
+				t.Fatal("quitting lost unsaved global binding")
+			}
+		})
+	}
+}
+
+func TestCommandSequencesInPasteStayLiteral(t *testing.T) {
+	for _, pane := range []string{"agent", "review", "picker"} {
+		t.Run(pane, func(t *testing.T) {
+			s := terminalState(t)
+			if pane == "review" {
+				s.diffFocused = true
+			}
+			if pane == "picker" {
+				s.agentShortcut(0x1d)
+			}
+			payload := ansi.BracketedPasteStart + "text\x1b[103;9u\x1b[93;9u\x1b[119;9u\x1b[113;9u" + ansi.BracketedPasteEnd
+			for _, b := range []byte(payload) {
+				s.handleInput([]byte{b}, s.agentInput)
+			}
+			want := ""
+			if pane == "agent" {
+				want = payload
+			}
+			if len(s.agents) != 1 || s.review.Request != "" || s.agentInput.(*bytes.Buffer).String() != want || s.diffFocused != (pane == "review") {
+				t.Fatal("pasted Command shortcut executed or changed text")
+			}
+		})
+	}
+}
+
+func TestUnrelatedEscapeSequencesReachAgentUnchanged(t *testing.T) {
+	s := terminalState(t)
+	payload := "\x1b[A\x1bOAx\x1b[99;9u\x1b[103;17u\x1b[103;13u\x1b[103;5u\x1b[103;10u\x1b[?1u\x1b[103;9:4u\x1b[103;9;103u\x03\t"
+	for _, b := range []byte(payload) {
+		s.handleInput([]byte{b}, s.agentInput)
+	}
+	if got := s.agentInput.(*bytes.Buffer).String(); got != payload || s.diffFocused {
+		t.Fatalf("unrelated input changed: %q", got)
+	}
+	s.handleInput([]byte{27}, s.agentInput)
+	s.decodeInput(true)
+	if got := s.agentInput.(*bytes.Buffer).String(); got != payload+"\x1b" {
+		t.Fatalf("Escape timeout lost input: %q", got)
+	}
+}
+
+func TestCommandModifiersAndKeyEvents(t *testing.T) {
+	s := terminalState(t)
+	for _, seq := range []string{"\x1b[103;9:2u", "\x1b[103;9:3u"} {
+		s.handleInput([]byte(seq), s.agentInput)
+		if s.diffFocused || s.agentInput.(*bytes.Buffer).Len() != 0 {
+			t.Fatal("repeat or release executed or leaked")
+		}
+	}
+	s.handleInput([]byte("\x1b[103;201:1u"), s.agentInput) // Both lock modifiers.
+	if !s.diffFocused {
+		t.Fatal("lock modifiers blocked Command-G")
+	}
+	s.handleInput([]byte("\x1b[103:71:103;9u"), s.agentInput)
+	if s.diffFocused {
+		t.Fatal("alternate key codes blocked Command-G")
+	}
+}

--- a/internal/app/mouse.go
+++ b/internal/app/mouse.go
@@ -70,21 +70,16 @@ func (s *screenState) mouse(sequence string) {
 	}
 	s.mouseDragging = false
 	if y >= s.layout.FooterY {
-		key := ui.ControlKeyAt(s.layout.Width, x, y-s.layout.FooterY, true, &s.review)
-		if key == "focus" {
-			if !s.exited {
-				s.diffFocused = false
-				s.fullscreen = false
-				s.relayout(s.layout.Width, s.layout.Height)
-			}
-		} else if key == "new-agent" || key == "next-agent" || key == "previous-agent" || key == "close-agent" {
-			s.agentShortcut(map[string]byte{"new-agent": 0x1d, "next-agent": 0x0e, "previous-agent": 0x10, "close-agent": 0x17}[key])
-		} else if key == "quit-app" {
-			s.review.Request = key
-		} else if key != "" {
-			s.review.Key(key, s.visibleLines())
-		}
+		key := ui.ControlKeyAt(s.layout.Width, x, y-s.layout.FooterY+ui.FooterStart(s.layout.Width, s.layout.FooterHeight, &s.review), true, &s.review)
+		s.activateFooter(key)
 		return
+	}
+	if s.review.FooterFocused {
+		s.review.FooterFocused = false
+		if x < s.layout.DiffX || x >= s.layout.DiffX+s.layout.DiffWidth || y < s.layout.DiffY {
+			return
+		}
+		s.diffFocused = true
 	}
 	if x < s.layout.DiffX || x >= s.layout.DiffX+s.layout.DiffWidth {
 		return

--- a/internal/app/preferences.go
+++ b/internal/app/preferences.go
@@ -2,50 +2,115 @@ package app
 
 import (
 	"encoding/json"
-	"github.com/nccapo/stvena/internal/review"
-	"github.com/nccapo/stvena/internal/session"
 	"os"
 	"path/filepath"
+
+	"github.com/nccapo/stvena/internal/review"
+	"github.com/nccapo/stvena/internal/session"
 )
 
 type preferences struct {
 	Ratio            int
 	Wrap, SideBySide bool
-	Hotkeys          map[string]string `json:",omitempty"`
+	Hotkeys          map[string]string `json:",omitempty"` // Read older repository settings.
+}
+
+type hotkeyPreferences struct {
+	Hotkeys map[string]string
+}
+
+var preferencesConfigDir = os.UserConfigDir
+
+func hotkeysPath() (string, error) {
+	dir, err := preferencesConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "stvena", "hotkeys.json"), nil
 }
 
 func (s *screenState) loadPreferences() {
-	dir, err := session.RepoDir(s.root)
-	if err != nil {
-		return
-	}
-	data, err := os.ReadFile(filepath.Join(dir, "layout.json"))
-	if err != nil {
-		return
-	}
 	var p preferences
-	if json.Unmarshal(data, &p) != nil {
-		return
+	if dir, err := session.RepoDir(s.root); err == nil {
+		if data, err := os.ReadFile(filepath.Join(dir, "layout.json")); err == nil && json.Unmarshal(data, &p) == nil {
+			if p.Ratio >= 25 && p.Ratio <= 75 {
+				s.ratio = p.Ratio
+			}
+			s.review.Wrap = p.Wrap
+			s.review.SideBySide = p.SideBySide
+		} else {
+			p = preferences{}
+		}
 	}
-	if p.Ratio >= 25 && p.Ratio <= 75 {
-		s.ratio = p.Ratio
-	}
-	s.review.Wrap = p.Wrap
-	s.review.SideBySide = p.SideBySide
-	s.review.Hotkeys = nil
-	if err := review.ValidateHotkeys(p.Hotkeys); err != nil {
-		s.review.Notice = "Invalid saved hotkeys; using defaults: " + err.Error()
-	} else {
-		s.review.Hotkeys = p.Hotkeys
-	}
+	s.loadHotkeys(p.Hotkeys)
 	s.relayout(s.layout.Width, s.layout.Height)
 }
+
+func (s *screenState) loadHotkeys(legacy map[string]string) {
+	s.review.Hotkeys = nil
+	s.review.HotkeysDirty = false
+	path, err := hotkeysPath()
+	if err != nil {
+		s.review.Notice = "Could not load hotkeys: " + err.Error()
+		return
+	}
+	data, err := os.ReadFile(path)
+	var p hotkeyPreferences
+	switch {
+	case os.IsNotExist(err):
+		p.Hotkeys = legacy
+	case err != nil:
+		s.review.Notice = "Could not load hotkeys: " + err.Error()
+		return
+	default:
+		if err := json.Unmarshal(data, &p); err != nil {
+			s.review.Notice = "Invalid saved hotkeys; using defaults: " + err.Error()
+			return
+		}
+	}
+	if err := review.ValidateHotkeys(p.Hotkeys); err != nil {
+		s.review.Notice = "Invalid saved hotkeys; using defaults: " + err.Error()
+		return
+	}
+	s.review.Hotkeys = p.Hotkeys
+	// The first opened project with custom bindings seeds the shared settings.
+	// An existing shared file, including an explicit reset, always wins.
+	if os.IsNotExist(err) && len(legacy) > 0 {
+		s.review.HotkeysDirty = true
+		if err := s.saveHotkeys(); err != nil {
+			s.review.Notice = "Hotkeys active, but could not save: " + err.Error()
+		}
+	}
+}
+
+func (s *screenState) saveHotkeys() error {
+	if !s.review.HotkeysDirty {
+		return nil
+	}
+	path, err := hotkeysPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	if err := session.AtomicJSON(path, hotkeyPreferences{Hotkeys: s.review.Hotkeys}); err != nil {
+		return err
+	}
+	s.review.HotkeysDirty = false
+	return nil
+}
+
 func (s *screenState) savePreferences() error {
+	// Unedited windows must not overwrite shortcuts saved by another project.
+	if err := s.saveHotkeys(); err != nil {
+		return err
+	}
 	dir, err := session.RepoDir(s.root)
 	if err != nil {
 		return err
 	}
 	return session.AtomicJSON(filepath.Join(dir, "layout.json"), preferences{
-		Ratio: s.ratio, Wrap: s.review.Wrap, SideBySide: s.review.SideBySide, Hotkeys: s.review.Hotkeys,
+		Ratio: s.ratio, Wrap: s.review.Wrap, SideBySide: s.review.SideBySide,
 	})
 }

--- a/internal/app/terminals.go
+++ b/internal/app/terminals.go
@@ -193,7 +193,7 @@ func (s *screenState) closeActiveAgent() {
 	}
 	s.review.Notice = "Agent closed"
 	if len(s.agents) == 0 {
-		s.review.Notice += " · Ctrl-]: new agent · q exits"
+		s.review.Notice += " · " + s.review.Binding("Ctrl-]") + ": new agent · q exits"
 	}
 }
 
@@ -211,7 +211,7 @@ func (s *screenState) agentExited(a *agentTerminal, err error) {
 	s.syncAgent()
 	s.diffFocused = true
 	s.review.Browser = true
-	s.review.Notice = "Agent finished · Ctrl-]: new agent · Ctrl-N/P: switch agents"
+	s.review.Notice = "Agent finished · " + s.review.Binding("Ctrl-]") + ": new agent · " + s.review.Binding("Ctrl-N") + "/" + s.review.Binding("Ctrl-P") + ": switch agents"
 	if !s.agentsRunning() {
 		s.review.Notice += " · q exits"
 	}

--- a/internal/app/terminals_integration_test.go
+++ b/internal/app/terminals_integration_test.go
@@ -36,6 +36,7 @@ func TestAgentTerminalsEndToEnd(t *testing.T) {
 				fmt.Printf("input:%d:%s\r\n", os.Getpid(), buffer[:n])
 			}
 		}
+		preferencesConfigDir = func() (string, error) { return os.Getenv("STVENA_TEST_CONFIG"), nil }
 		err := Run([]string{os.Args[0], "-test.run=^TestAgentTerminalsEndToEnd$", "--", "agent"})
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
@@ -64,7 +65,7 @@ func exerciseAgentTerminals(t *testing.T, width int, helper string) {
 			t.Fatal(err)
 		}
 	}
-	command.Env = append(os.Environ(), helper+"=1", "PATH="+agentBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	command.Env = append(os.Environ(), helper+"=1", "STVENA_TEST_CONFIG="+t.TempDir(), "PATH="+agentBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	command.Dir = t.TempDir()
 	if output, err := exec.Command("git", "init", "--quiet", command.Dir).CombinedOutput(); err != nil {
 		t.Fatalf("init test repository: %v: %s", err, output)
@@ -135,12 +136,35 @@ func exerciseAgentTerminals(t *testing.T, width int, helper string) {
 	}
 	send := func(text string) {
 		t.Helper()
+		if width == 140 {
+			text = strings.NewReplacer("\x07", "\x1b[103;9u", "\x1d", "\x1b[93;9u", "\x0e", "\x1b[110;9u", "\x10", "\x1b[112;9u", "\x17", "\x1b[119;9u", "\x11", "\x1b[113;9u").Replace(text)
+		}
 		if _, err := ptmx.WriteString(text); err != nil {
 			t.Fatal(err)
 		}
 	}
 	ready := regexp.MustCompile(`ready:(\d+)`)
 	first := ready.FindStringSubmatch(waitFor("ready:"))[1]
+	// Startup offers Configuration without needing Ctrl-G or a function key.
+	if !strings.Contains(screen(), "BOTTOM PANEL") {
+		t.Fatal("startup did not focus the bottom panel")
+	}
+	// Escape lets users start typing immediately; the other width checks the
+	// direct startup route to Configuration.
+	if width == 80 {
+		send("\x1b")
+		send("startup-input")
+		waitFor("input:" + first + ":startup-input")
+		send("\x1b[17~")
+		waitFor("BOTTOM PANEL")
+	}
+	send("\x1b[D\x1b[C\r")
+	waitFor("CONFIGURATION")
+	send("\r\x0f")
+	waitFor("Hotkeys saved for all projects")
+	send("?\x0f")
+	send("\x07released")
+	waitFor("input:" + first + ":released")
 	send("first")
 	waitFor("input:" + first + ":first")
 	send("\x1d")

--- a/internal/app/workspace.go
+++ b/internal/app/workspace.go
@@ -112,12 +112,11 @@ func (s *screenState) setCheck(r checks.Result) {
 }
 func (s *screenState) dispatch(ctx context.Context, events chan<- any, stop <-chan struct{}) bool {
 	if s.review.HotkeysDirty {
-		s.review.HotkeysDirty = false
 		s.relayout(s.layout.Width, s.layout.Height)
 		if err := s.savePreferences(); err != nil {
 			s.review.Notice = "Hotkeys active, but could not save: " + err.Error()
 		} else {
-			s.review.Notice = "Hotkeys saved for this repository"
+			s.review.Notice = "Hotkeys saved for all projects"
 		}
 	}
 	r := s.review.Request
@@ -160,7 +159,7 @@ func (s *screenState) dispatch(ctx context.Context, events chan<- any, stop <-ch
 		if !s.agentsRunning() {
 			return true
 		}
-		s.review.Notice = "An agent is still running · Ctrl-Q closes stvena and stops all agents"
+		s.review.Notice = "An agent is still running · " + s.review.Binding("Ctrl-Q") + " closes stvena and stops all agents"
 	case "fullscreen":
 		s.fullscreen = !s.fullscreen
 		s.relayout(s.layout.Width, s.layout.Height)

--- a/internal/review/global_hotkeys.go
+++ b/internal/review/global_hotkeys.go
@@ -1,0 +1,67 @@
+package review
+
+import "strings"
+
+// GlobalHotkeyActions run from either pane. F6 stays fixed as a recovery path.
+var GlobalHotkeyActions = []Action{
+	{"Ctrl-G", "Switch panes", "Switch between the agent and review"},
+	{"Ctrl-]", "New agent", "Choose a command for another agent terminal"},
+	{"Ctrl-N", "Next agent", "Select the next agent terminal"},
+	{"Ctrl-P", "Previous agent", "Select the previous agent terminal"},
+	{"Ctrl-W", "Close agent", "Stop and close the current agent terminal"},
+	{"Ctrl-Q", "Quit all", "Close Stvena and stop all running agents"},
+}
+
+func IsGlobalHotkey(key string) bool {
+	for _, action := range GlobalHotkeyActions {
+		if action.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+// ControlKey names the byte encodings used by ordinary terminal Ctrl chords.
+func ControlKey(b byte) string {
+	if b >= 1 && b <= 26 {
+		return "Ctrl-" + string(rune('A'+b-1))
+	}
+	if b >= 28 && b <= 31 {
+		return "Ctrl-" + string(rune('\\'+b-28))
+	}
+	return ""
+}
+
+func ControlByte(key string) byte {
+	if key == "" {
+		return 0
+	}
+	for b := byte(1); b <= 31; b++ {
+		if ControlKey(b) == key {
+			return b
+		}
+	}
+	return 0
+}
+
+func validGlobalHotkey(key string) bool {
+	b := ControlByte(key)
+	// Keep interrupt, text-entry and existing review navigation keys available.
+	return b != 0 && !strings.ContainsRune("\x03\x04\x08\x09\x0a\x0d\x15", rune(b))
+}
+
+func (s *State) GlobalAction(key string) string {
+	if key == "" {
+		return ""
+	}
+	for _, action := range GlobalHotkeyActions {
+		if s.Binding(action.Key) == key {
+			return action.Key
+		}
+	}
+	return ""
+}
+
+func (s *State) EditingGlobalHotkey() bool {
+	return s.Help && s.EditingHotkey && s.HelpIndex >= 0 && s.HelpIndex < len(HotkeyActions) && IsGlobalHotkey(HotkeyActions[s.HelpIndex].Key)
+}

--- a/internal/review/hotkeys.go
+++ b/internal/review/hotkeys.go
@@ -5,9 +5,9 @@ import (
 	"unicode"
 )
 
-// HotkeyActions describes the character shortcuts. Named navigation keys and
-// global terminal controls stay fixed so the editor is always accessible.
-var HotkeyActions = append([]Action{
+// HotkeyActions includes review keys and global controls. F6 always reaches
+// the footer so a conflicting shortcut cannot lock users out of configuration.
+var HotkeyActions = append(append([]Action{
 	{"a", "Actions menu", "Open all review actions"},
 	{"f", "File browser", "Return to the file list"},
 	{"n", "Next file", "Select the next file"},
@@ -25,7 +25,7 @@ var HotkeyActions = append([]Action{
 	{"M", "Previous text match", "Find the previous search result"},
 	{"i", "Edit context request", "Edit your question for the agent"},
 	{"o", "Check problems", "Open source locations from check results"},
-}, Actions...)
+}, Actions...), GlobalHotkeyActions...)
 
 func (s *State) Binding(key string) string {
 	if custom := s.Hotkeys[key]; custom != "" {
@@ -54,7 +54,11 @@ func ValidateHotkeys(bindings map[string]string) error {
 		known[action.Key] = true
 		key := action.Key
 		if custom, ok := bindings[key]; ok {
-			if !validHotkey(custom) {
+			if IsGlobalHotkey(action.Key) {
+				if !validGlobalHotkey(custom) {
+					return fmt.Errorf("Use a Ctrl key; Ctrl-C/D/H/I/J/M/U and F6 stay fixed")
+				}
+			} else if !validHotkey(custom) {
 				return fmt.Errorf("Use one printable key; ?, j and k stay fixed")
 			}
 			key = custom

--- a/internal/review/hotkeys_test.go
+++ b/internal/review/hotkeys_test.go
@@ -114,3 +114,31 @@ func TestHotkeyValidation(t *testing.T) {
 		t.Fatal("reset silently overwrote another shortcut")
 	}
 }
+
+func TestGlobalHotkeyValidationAndCapture(t *testing.T) {
+	for _, key := range []string{"", "r", "F6", "Ctrl-C", "Ctrl-D", "Ctrl-H", "Ctrl-I", "Ctrl-J", "Ctrl-M", "Ctrl-U", "Ctrl-[", "Ctrl-N"} {
+		s := State{}
+		if err := s.SetHotkey("Ctrl-G", key); err == nil {
+			t.Errorf("accepted unavailable or conflicting global shortcut %q", key)
+		}
+	}
+	s := State{Help: true}
+	for i, action := range HotkeyActions {
+		if action.Key == "Ctrl-G" {
+			s.HelpIndex = i
+			break
+		}
+	}
+	s.InputKey("enter", 20)
+	s.InputKey("Ctrl-O", 20)
+	if s.EditingHotkey || s.Binding("Ctrl-G") != "Ctrl-O" || !s.HotkeysDirty {
+		t.Fatal("global shortcut capture failed")
+	}
+	s.InputKey("backspace", 20)
+	if s.Binding("Ctrl-G") != "Ctrl-G" {
+		t.Fatal("reset did not restore global shortcut")
+	}
+	if err := s.SetHotkey("a", "Ctrl-O"); err == nil {
+		t.Fatal("review shortcut accepted a global chord")
+	}
+}

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -23,6 +23,8 @@ type State struct {
 	Searching, PatchFocused, Help     bool
 	Hotkeys                           map[string]string
 	HelpIndex                         int
+	FooterFocused                     bool
+	FooterIndex                       int
 	EditingHotkey, HotkeysDirty       bool
 	Browser, FullFile                 bool
 	Content                           diffview.Content
@@ -207,6 +209,10 @@ func (s *State) Key(key string, visible int) {
 		s.Notice = ""
 		return
 	}
+	if s.Help {
+		s.helpKey(key)
+		return
+	}
 	if s.Selecting && !s.Menu && s.Prompt == "" && s.Panel == "" && !s.Help && !s.Searching {
 		switch key {
 		case "f", "esc", "backspace", "n", "p", "v", "s", "view-file", "view-diff":
@@ -245,10 +251,6 @@ func (s *State) Key(key string, visible int) {
 		}
 		s.Selected, s.Scroll = 0, 0
 		s.filter("")
-		return
-	}
-	if s.Help {
-		s.helpKey(key)
 		return
 	}
 	if s.Panel != "" && s.Prompt == "" && s.ConfirmAction == "" && !s.Menu {

--- a/internal/ui/hotkeys.go
+++ b/internal/ui/hotkeys.go
@@ -31,7 +31,7 @@ func renderHelp(s *review.State, width, height int) []string {
 			rows[row] = reviewRow(" "+text, width)
 		}
 	}
-	put(0, headerBG+bold+"REVIEW CONTROLS · Configure hotkeys")
+	put(0, headerBG+bold+"CONFIGURATION · Review and global shortcuts")
 	put(1, "↑/↓: select · Enter / click: change · Esc: back")
 	put(2, muted+"Backspace: reset key · Delete: reset all · * custom")
 	start, count := HelpListWindow(s, height)
@@ -45,12 +45,15 @@ func renderHelp(s *review.State, width, height int) []string {
 		if s.Binding(action.Key) != action.Key {
 			custom = "*"
 		}
-		put(3+i-start, style+fmt.Sprintf("%s%-5s %s %s", marker, review.KeyLabel(s.Binding(action.Key)), custom, action.Name)+reset)
+		put(3+i-start, style+fmt.Sprintf("%s%-7s %s %s", marker, review.KeyLabel(s.Binding(action.Key)), custom, action.Name)+reset)
 	}
-	footer := "Changes save automatically for this repository"
+	footer := "Changes save automatically for all projects"
 	if s.EditingHotkey {
 		action := review.HotkeyActions[s.HelpIndex]
 		footer = "Press a printable key for " + action.Name + " · Esc: cancel"
+		if review.IsGlobalHotkey(action.Key) {
+			footer = "Press a Ctrl key for " + action.Name + " · Esc: cancel"
+		}
 	}
 	if s.Notice != "" {
 		footer = s.Notice

--- a/internal/ui/hotkeys_test.go
+++ b/internal/ui/hotkeys_test.go
@@ -62,7 +62,7 @@ func TestCustomHotkeyLabelsKeepCanonicalClickActions(t *testing.T) {
 			for x := 0; x < width; x++ {
 				if ControlKeyAt(width, x, y, true, &s) == "b" {
 					found = true
-					if !strings.Contains(plain, "界: Add to agent") {
+					if !strings.Contains(plain, "界: Paste to agent") {
 						t.Fatal("footer hit testing did not use custom label widths")
 					}
 				}
@@ -70,6 +70,52 @@ func TestCustomHotkeyLabelsKeepCanonicalClickActions(t *testing.T) {
 		}
 		if !found {
 			t.Fatal("custom footer control has no click target")
+		}
+	}
+}
+
+func TestGlobalShortcutLabelsMatchFooterClickTargets(t *testing.T) {
+	for _, width := range []int{35, 80, 140} {
+		rows := controlRows(width, false)
+		for key, action := range map[string]string{"G": "focus", "]": "new-agent", "N": "next-agent", "P": "previous-agent", "W": "close-agent", "Q": "quit-app"} {
+			label := ("Ctrl-" + key) + ":"
+			found := false
+			for y, row := range rows {
+				plain := ansi.Strip(row)
+				if x := strings.Index(plain, label); x >= 0 {
+					found = true
+					if got := ControlKeyAt(width, x, y, false); got != action {
+						t.Fatalf("%s clicked %s, want %s", label, got, action)
+					}
+				}
+			}
+			if !found {
+				t.Fatalf("missing %s at width %d", label, width)
+			}
+		}
+	}
+}
+
+func TestFooterNavigationAndCustomGlobalLabels(t *testing.T) {
+	s := review.State{FooterFocused: true, Hotkeys: map[string]string{"Ctrl-G": "Ctrl-O"}}
+	for _, width := range []int{35, 80, 140} {
+		rows := controlRows(width, false, &s)
+		if !strings.Contains(ansi.Strip(strings.Join(rows, "\n")), "Ctrl-O: Switch panes") || strings.Contains(ansi.Strip(strings.Join(rows, "\n")), "Ctrl-G:") {
+			t.Fatal("footer did not reflect global remapping")
+		}
+		for index := range FooterControls {
+			s.FooterIndex = index
+			rows = controlRows(width, false, &s)
+			start := FooterStart(width, 2, &s)
+			if start >= len(rows) || !strings.Contains(strings.Join(rows[start:min(start+2, len(rows))], ""), "\x1b[7m") {
+				t.Fatalf("selection %d invisible at width %d", index, width)
+			}
+			if next := FooterMove(width, index, "right", &s); next != (index+1)%len(FooterControls) {
+				t.Fatal("Right did not traverse footer")
+			}
+		}
+		if FooterMove(width, 0, "up", &s) != -1 {
+			t.Fatal("Up did not leave first footer row")
 		}
 	}
 }

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -118,13 +118,19 @@ func Render(w io.Writer, terminal *vt.Emulator, state *review.State, layout Layo
 	}
 
 	controls := controlRows(layout.Width, diffFocused, state)
-	if !diffFocused && state.AgentDraft {
-		controls[0] = cyan + bold + " Type request · Enter: send · Ctrl-G: Switch panes" + reset
+	if state.FooterFocused {
+		target := "agent"
+		if diffFocused {
+			target = "review"
+		}
+		rows[0] = reviewRow(headerBG+bold+" BOTTOM PANEL · Arrows: move · Enter: select · Esc: "+target, layout.Width)
+		cursorVisible = false
 	}
+	footerStart := FooterStart(layout.Width, layout.FooterHeight, state)
 	for y := 0; y < layout.FooterHeight; y++ {
 		text := ""
-		if y < len(controls) {
-			text = controls[y]
+		if footerStart+y < len(controls) {
+			text = controls[footerStart+y]
 		}
 		rows[layout.FooterY+y] = reviewRow(headerBG+text, layout.Width)
 	}
@@ -234,27 +240,47 @@ func controlRows(width int, diffFocused bool, state ...*review.State) []string {
 		separator := strings.LastIndex(control, ":")
 		key, label := control[:separator], control[separator+1:]
 		style := cyan + bold
-		if !diffFocused && i > 0 && !strings.HasPrefix(control, "Ctrl-") {
+		if !diffFocused && !review.IsGlobalHotkey(FooterControls[i].Key) && FooterControls[i].Key != "F6" {
 			style = muted
 		}
-		row += gap + style + key + reset + headerBG + ":" + label
+		if len(state) > 0 && state[0] != nil && state[0].FooterFocused && state[0].FooterIndex == i {
+			row += gap + "\x1b[7m" + bold + key + ":" + label + reset + headerBG
+		} else {
+			row += gap + style + key + reset + headerBG + ":" + label
+		}
 	}
 	return append(rows, row)
 }
 
+type FooterControl struct{ Key, Action, Label string }
+
+var FooterControls = []FooterControl{
+	{"Ctrl-G", "focus", "Switch panes"}, {"Ctrl-]", "new-agent", "New agent"},
+	{"Ctrl-N", "next-agent", "Next agent"}, {"Ctrl-P", "previous-agent", "Previous agent"},
+	{"Ctrl-W", "close-agent", "Close agent"},
+	{"1", "1", "Changes"}, {"2", "2", "Workspace"}, {"3", "3", "Files"},
+	{"B", "B", "Context"}, {"b", "b", "Paste to agent"}, {"T", "T", "Checks"},
+	{"K", "K", "Checkpoint"}, {"a", "a", "Actions"}, {"F", "F", "Expand"},
+	{"?", "?", "Configuration"}, {"Ctrl-Q", "quit-app", "Quit all"}, {"F6", "footer", "Bottom panel"},
+}
+
 func footerControls(state ...*review.State) []string {
-	controls := []string{"Ctrl-G: Switch panes", "Ctrl-]: New agent", "Ctrl-N: Next agent", "Ctrl-P: Previous agent", "Ctrl-W: Close agent", "3: Files", "1: Changes", "2: Workspace", "T: Checks", "B: Context", "b: Add to agent", "a: Actions", "F: Expand", "?: Hotkeys", "Ctrl-Q: quit all"}
-	if len(state) > 0 && state[0] != nil {
-		for i, control := range controls {
-			key, label, _ := strings.Cut(control, ":")
-			controls[i] = review.KeyLabel(state[0].Binding(key)) + ":" + label
+	controls := make([]string, len(FooterControls))
+	for i, control := range FooterControls {
+		key := control.Key
+		if len(state) > 0 && state[0] != nil {
+			key = state[0].Binding(key)
 		}
+		controls[i] = review.KeyLabel(key) + ": " + control.Label
 	}
 	return controls
 }
-func ControlKeyAt(width, x, y int, _ bool, state ...*review.State) string {
+
+type footerPosition struct{ x, y, width int }
+
+func footerPositions(width int, state ...*review.State) []footerPosition {
+	positions := make([]footerPosition, len(FooterControls))
 	row, column := 0, 1
-	keys := []string{"focus", "new-agent", "next-agent", "previous-agent", "close-agent", "3", "1", "2", "T", "B", "b", "a", "F", "?", "quit-app"}
 	for i, label := range footerControls(state...) {
 		gap := 0
 		if column > 1 {
@@ -262,14 +288,66 @@ func ControlKeyAt(width, x, y int, _ bool, state ...*review.State) string {
 		}
 		if column+gap+ansiWidth(label) > width && column > 1 {
 			row++
-			column = 1
-			gap = 0
+			column, gap = 1, 0
 		}
 		column += gap
-		if row == y && x >= column && x < column+ansiWidth(label) {
-			return keys[i]
-		}
+		positions[i] = footerPosition{column, row, ansiWidth(label)}
 		column += ansiWidth(label)
+	}
+	return positions
+}
+
+// FooterMove follows visual rows when the footer wraps. -1 returns to the pane.
+func FooterMove(width, index int, key string, state *review.State) int {
+	positions := footerPositions(width, state)
+	index = min(max(0, index), len(positions)-1)
+	switch key {
+	case "left":
+		return (index + len(positions) - 1) % len(positions)
+	case "right", "tab":
+		return (index + 1) % len(positions)
+	case "home":
+		return 0
+	case "end":
+		return len(positions) - 1
+	case "up", "down":
+		row := positions[index].y + 1
+		if key == "up" {
+			row = positions[index].y - 1
+		}
+		if row < 0 {
+			return -1
+		}
+		best, distance := index, int(^uint(0)>>1)
+		for i, p := range positions {
+			delta := p.x - positions[index].x
+			if delta < 0 {
+				delta = -delta
+			}
+			if p.y == row && delta < distance {
+				best, distance = i, delta
+			}
+		}
+		return best
+	}
+	return index
+}
+
+// FooterStart keeps keyboard selection visible when only a few rows fit.
+func FooterStart(width, height int, state *review.State) int {
+	if state == nil || !state.FooterFocused {
+		return 0
+	}
+	positions := footerPositions(width, state)
+	index := min(max(0, state.FooterIndex), len(positions)-1)
+	return max(0, positions[index].y-height+1)
+}
+
+func ControlKeyAt(width, x, y int, _ bool, state ...*review.State) string {
+	for i, p := range footerPositions(width, state...) {
+		if p.y == y && x >= p.x && x < p.x+p.width {
+			return FooterControls[i].Action
+		}
 	}
 	return ""
 }

--- a/internal/ui/review.go
+++ b/internal/ui/review.go
@@ -181,7 +181,7 @@ func renderReview(s *review.State, width, height int, focused bool) []string {
 			} else {
 				add(dim + " Working tree is clean.")
 			}
-			add(cyan + " Ctrl-G: Switch panes · a: Actions")
+			add(cyan + " " + s.Binding("Ctrl-G") + ": Switch panes · " + s.Binding("a") + ": Actions")
 		} else {
 			add(dim + " No files match this view. Esc clears filter.")
 		}

--- a/internal/ui/review_controls.go
+++ b/internal/ui/review_controls.go
@@ -74,7 +74,7 @@ func reviewFooter(s *review.State) string {
 		return cyan + " " + safeText(s.Notice)
 	}
 	if s.Help {
-		return muted + " Ctrl-G: Switch panes  ?: help"
+		return muted + " " + s.Binding("Ctrl-G") + ": Switch panes  ?: configuration"
 	}
 	return reviewControlBar(s)
 }

--- a/internal/ui/welcome.go
+++ b/internal/ui/welcome.go
@@ -44,7 +44,7 @@ func renderWelcome(s *review.State, width, height int, focused bool) []string {
 			"",
 			pulse + "●" + reset + muted + " " + status,
 			"",
-			cyan + "Ctrl-G" + reset + "  " + fitANSI("Switch panes", 23),
+			cyan + s.Binding("Ctrl-G") + reset + "  " + fitANSI("Switch panes", 23),
 			cyan + "     v" + reset + "  " + fitANSI("See the whole file", 23),
 			cyan + "Drag+b" + reset + "  Add code to agent draft",
 		}


### PR DESCRIPTION
Shortcut settings were tied to individual repositories, and a conflicting Ctrl-G could prevent users from reaching Configuration. This change saves review and global shortcuts in the user configuration directory and starts Stvena with Configuration selected in the bottom panel. Enter opens settings, arrows navigate the panel, and Esc sends subsequent typing to the agent or standalone review.

Global pane, agent-terminal, and quit shortcuts can now be reassigned. For example, changing pane switching to Ctrl-O releases Ctrl-G to the agent. Existing repository bindings migrate when no shared settings exist; layouts remain project-specific, global resets take precedence, and closing an unedited window does not overwrite newer shared settings.

The footer includes pane and agent controls, Changes, Workspace, Files, Context, Paste to agent, Checks, Checkpoint, Actions, Expand, Configuration, and Quit. It supports keyboard and mouse navigation, keeps selection visible when rows wrap, and reflects custom bindings. Ctrl remains the default; forwarded Command sequences are supported as optional aliases. F6 is an optional way to return to the footer, with no shortcut required at startup.

Validation:

- `go test -race ./...`
- `go vet ./...` and `go build ./...`
- Formatting, `git diff --check`, and installer shell syntax checks
- `gitleaks dir . --redact --no-banner`: no leaks found
- Real PTY integration tests at 80 and 140 columns cover startup Configuration, remapping, agent input, switching, and shutdown. Regression tests also cover cross-project persistence, migration/reset, pasted shortcuts, fragmented input, and Escape followed immediately by typing.
