### PR TITLE
feat: preview live editor integration with binary and VSIX releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,31 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/**']
   pull_request:
 
 permissions:
   contents: read
 
 jobs:
+  editor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: extensions/vscode
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: extensions/vscode/package-lock.json
+      - run: npm ci
+      - run: npm test
+      - run: npm run package
   test:
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:
@@ -22,8 +22,29 @@ jobs:
           go-version-file: go.mod
           cache: true
       - name: Test
-        run: go test ./...
-      - name: Release binaries
+        run: |
+          test -z "$(gofmt -l cmd internal)"
+          sh -n install.sh
+          go vet ./...
+          go test -race ./...
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: extensions/vscode/package-lock.json
+      - name: Test and package editor extension
+        working-directory: extensions/vscode
+        env:
+          STVENA_SOURCE_REF: ${{ github.ref_name }}
+        run: |
+          npm ci
+          npm test
+          if [[ "$STVENA_SOURCE_REF" == *-* ]]; then
+            npm run package -- --pre-release
+          else
+            npm run package
+          fi
+      - name: Release binaries and VSIX
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ secrets.json
 *.prof
 coverage.*
 *.log
+node_modules/
+*.vsix
 
 # Local recordings: publish a reviewed demo as a GitHub attachment
 *.mp4

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,6 +27,8 @@ archives:
 
 checksum:
   name_template: checksums.txt
+  extra_files:
+    - glob: ./extensions/vscode/stvena-live-*.vsix
 
 changelog:
   sort: asc
@@ -37,3 +39,5 @@ changelog:
 
 release:
   prerelease: auto
+  extra_files:
+    - glob: ./extensions/vscode/stvena-live-*.vsix

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,13 +57,27 @@ git tag -a v0.1.0 -m "Stvena v0.1.0"
 git push origin v0.1.0
 ```
 
-The release workflow runs the tests, creates the GitHub release, and uploads the
-archives and checksum file consumed by `install.sh`. Test the installer against
+The release workflow runs Go and extension tests, packages Stvena Live, creates
+the GitHub release, and uploads the four binary archives, VSIX, and checksum file
+consumed by `install.sh`. Node.js 22 and `npm ci` are used for extension packaging.
+Tags with a prerelease suffix (for example `v0.2.0-preview.1`) create GitHub
+prereleases and mark the VSIX as a prerelease. Binary and extension versions are
+independent; bump `extensions/vscode/package.json` and its lockfile together when
+the extension changes. The VSIX README links point at the release tag.
+
+Test the installer against
 the new version before updating release announcements:
 
 ```sh
 STVENA_VERSION=v0.1.0 STVENA_INSTALL_DIR="$(mktemp -d)" ./install.sh
 ```
+
+For previews, provide installation instructions with the explicit tag: GitHub's
+`latest` download URL continues to select a stable release. The first editor
+preview's release notes are in [docs/preview-release.md](docs/preview-release.md).
+Verify the downloaded VSIX in isolated VS Code and Antigravity profiles before
+announcing a preview. Do not commit generated VSIX files; release packaging uses
+a fresh checkout so old local packages cannot enter the release.
 
 ## Demo in the README
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ If Stvena saves you from the "open the IDE just for the diff" loop, consider
 - **Give the agent precise context.** Select code with the mouse or keyboard,
   collect snippets across files, and paste an assembled draft into the agent.
   You decide when to submit it.
+- **Run multiple agents at once.** Keep independent Codex and Claude Code
+  terminals running, switch between them, and review their combined changes in
+  one workspace.
+- **Follow saved edits in your editor.** The experimental Stvena Live extension
+  lists each newly captured batch and opens the working source at its first
+  changed line while focus stays in the integrated terminal.
 - **Keep track of your review.** Pin a captured version, mark files and hunks
   reviewed, and see when a reviewed change has changed again.
 - **Check the code you are looking at.** Run a command in a temporary checkout
@@ -105,9 +111,9 @@ forwards them; see [terminal shortcut setup](docs/usage.md#command-keys-in-your-
 
 **Multiple agent terminals:** Ctrl-] opens a chooser: **c** starts Codex, **l**
 starts Claude Code, and **Enter** repeats your original command with its arguments.
-Run Codex and Claude side by side; Ctrl-N / Ctrl-P switch between them. Background
-agents keep running in the same repository, with one shared review workspace. Ctrl-W closes the current agent
-and stops its command. Ctrl-Q stops them all.
+Ctrl-N / Ctrl-P switch between terminals while background agents keep running.
+See [Work with multiple agents](#work-with-multiple-agents) for the complete
+workflow.
 
 Reopening a review compares a saved baseline with today's workspace; it does
 not resume an agent conversation. Other commands can run in the agent pane,
@@ -165,6 +171,72 @@ file, and **c** or **x** to save exact-line comments or selections across files.
 standalone review. **P** resumes live; changed items need review again. An open
 checkpoint and its feedback survive reopening a saved review.
 
+## Work with multiple agents
+
+Stvena can run several agent terminals in one session. Each terminal keeps its
+own screen, conversation, and unfinished input. The agent pane shows one terminal
+at a time, and the header identifies the active command and its position, such as
+`codex 1/2`. Other agents continue running in the background.
+
+Press **Ctrl-]** from either pane to open the new-agent chooser:
+
+- **c** starts Codex with its CLI defaults.
+- **l** starts Claude Code with its CLI defaults.
+- **Enter** starts the selected option. The initial option repeats the command
+  used to launch Stvena, including its arguments.
+
+Every new terminal starts in the original working directory. All agents share
+the same session baseline and review workspace, so changes from every agent
+appear together. Code selections and review drafts are pasted into the currently
+selected agent.
+
+Use **Ctrl-N** and **Ctrl-P** to move between agent terminals. **Ctrl-W** stops
+and closes the selected agent; finished terminals otherwise remain available for
+inspection. Closing the last agent leaves the review workspace open, where
+**Ctrl-]** can start another. **Ctrl-Q** stops every agent and exits Stvena.
+
+Agent terminals are live processes rather than saved conversations. Reopening a
+saved review does not restart them, and multiple-agent shortcuts are unavailable
+in standalone `stvena review` mode.
+
+## Follow reads and edits in VS Code
+
+An experimental [Stvena Live extension](extensions/vscode/README.md) follows
+captured edits in the editor while Stvena runs in its integrated terminal. It
+opens working source files at the changed line, lists the latest changed files,
+and lets you pause and resume following. Supported Codex and Claude tool hooks
+also report read locations. Blue read markers and amber edit markers show the
+relevant lines with an inline label; markers expire after 15 seconds. Codex
+requires its normal `/hooks` trust review before read reporting runs.
+
+Download the binary and `stvena-live-0.2.0.vsix` from the
+[GitHub preview release](https://github.com/nccapo/stvena/releases/tag/v0.2.0-preview.1).
+Install the preview binary on macOS or Linux:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/nccapo/stvena/v0.2.0-preview.1/install.sh | \
+  STVENA_VERSION=v0.2.0-preview.1 sh
+```
+
+In VS Code or Antigravity, install the downloaded `.vsix` with
+**Extensions: Install from VSIX…**, open a trusted local Git workspace, and run
+`stvena` in its integrated terminal. No Go or Node.js installation is needed.
+The preview is not yet published to a marketplace; the default Stvena installer
+still selects the stable release, so use the explicit preview version above.
+The extension targets VS Code 1.85 or newer. It reads saved
+file captures from the repository's Git directory; it does not run commands,
+write source, add telemetry, or expose a network service.
+
+Updates are snapshots sampled roughly every 700 ms plus capture and extension
+polling time. They include saved edits from every workspace writer, without
+per-agent attribution or guaranteed intermediate history. Automatic navigation
+skips deleted files and files with unsaved editor changes.
+
+The first target is the VS Code extension API. Zed requires a separate
+integration. See the extension guide for installation, compatibility, and
+capture limits, or the [bridge protocol](docs/editor-integration.md) to build
+another local editor integration.
+
 ## Privacy and local data
 
 Stvena does not require its own API key or account. It launches the agent CLI
@@ -202,6 +274,11 @@ go test ./...
 go test -race ./...
 go vet ./...
 go build ./...
+
+cd extensions/vscode
+npm ci
+npm test
+npm run package
 ```
 
 Maintainers publish the prebuilt archives and checksums by pushing a semantic
@@ -216,7 +293,9 @@ release command and verification steps.
 | `internal/session` | Snapshot capture, retained refs, and session storage |
 | `internal/review` | Navigation, selections, review marks, and feedback |
 | `internal/checks` | Check execution, bounded logs, and problem locations |
+| `internal/editor` | Local editor bridge and captured-change protocol |
 | `internal/ui` | Terminal layout, code rendering, and controls |
+| `extensions/vscode` | Stvena Live editor navigation and latest-change view |
 
 The [product direction](docs/product-direction.md) and
 [research notes](docs/competitive-research.md) describe ideas and tradeoffs;

--- a/docs/editor-integration.md
+++ b/docs/editor-integration.md
@@ -1,0 +1,111 @@
+# Editor integration
+
+Stvena's VS Code extension follows reported reads and consecutive captured workspace versions. It
+opens the working source with `showTextDocument`, selecting the changed line
+and preserving keyboard focus during automatic updates, as described in the
+[VS Code API](https://code.visualstudio.com/api/references/vscode-api#window.showTextDocument).
+Deleted files are not opened; automatic following skips unsaved buffers.
+Install instructions and product limits are in
+[extensions/vscode/README.md](../extensions/vscode/README.md).
+
+## Local bridge, version 1
+
+Resolve a workspace folder with `git rev-parse --show-toplevel`, then resolve that
+root's Git directory with `git rev-parse --absolute-git-dir`. Read
+`stvena-live.json` in that directory. Do not assume `.git` is a directory: linked
+worktrees use their own descriptors. The writer replaces the file atomically
+with owner-only permissions; it does not add files to the user's source tree.
+
+The JSON contains:
+
+| Field | Meaning |
+| --- | --- |
+| `version` | Protocol version, currently `1` |
+| `session` | Stvena session ID |
+| `sequence` | Advances when the captured tree changes; starts at zero |
+| `active` | False after normal watcher shutdown |
+| `updatedAt` | RFC 3339 UTC heartbeat; treat older than 30 seconds as disconnected |
+| `error` | Optional capture error; don't follow stale edits while present |
+| `changedAt` | Optional timestamp of the latest changed capture, unchanged by heartbeats |
+| `activity` | Optional latest reported read, expires after 15 seconds |
+| `files` | All changes in the latest changed capture, kept across idle heartbeats |
+
+Each file has `path`, optional rename `oldPath`, Git `status`, immutable blob
+object IDs `before` and `after`, one-based first changed `line`, `added` and
+`deleted` counts, and `binary` / `truncated` flags. Optional `ranges` contains one-based inclusive
+`{start, end}` changed spans in the new file; deletions point to a surviving
+neighbor, clamped at EOF. Older producers without ranges still navigate by `line`. An all-zero object ID means
+that side is absent. Read nonzero IDs with `git cat-file blob <oid>`; do not
+execute source text or interpret it as a command. Submodule objects are not text
+blobs and may fail text preview. Consumers must validate fields and paths.
+
+The first comparison starts at the saved session baseline. Later comparisons
+start at the last successfully published capture. Heartbeats do not advance the
+sequence. The bridge publishes even when the terminal review is pinned. A
+capture error preserves the last successful batch and reports an error until a
+successful capture. Descriptor-write failures also appear in the terminal.
+
+This is a latest-state protocol, without acknowledgements, replay, per-agent
+attribution, or an ordered history within each batch. Source retention follows
+Stvena's existing snapshot refs: do not treat old object IDs as a durable archive.
+One Stvena process per repository remains the supported model.
+
+## Read activity and visual markers
+
+`activity` carries `session`, unique `id`, `agent` command name, repository-relative
+`path`, one-based `line`, optional inclusive `endLine`, and RFC 3339 `updatedAt`.
+An omitted `endLine` means the range is unknown. Consumers validate paths,
+integers, timestamps, and session identity. Reads do not advance capture
+`sequence`; consumers independently track the activity ID. Read expiry never
+navigates back to an old edit. The newest reported event wins automatic follow.
+
+Standard Codex and Claude launches receive invocation-local PostToolUse hooks
+calling the same executable's `editor-hook` command. The child receives
+`STVENA_ACTIVITY_PATH`, `STVENA_ROOT`, `STVENA_SESSION`, and `STVENA_AGENT`.
+The observer parses supported inputs without executing command text, confines
+paths to the real repository root, and atomically writes location-only metadata
+to `<session-id>-activity.json` in Stvena's private cache. The snapshot publisher
+includes only fresh activity belonging to its session. Observer failures never
+approve, deny, or alter a tool call. Existing user settings are not written.
+See the [extension guide](../extensions/vscode/README.md#following-reads) for
+supported commands, hook trust, custom settings, and coverage limits.
+
+Read and edit ranges use separate whole-line decorations, gutter icons, inline
+labels, and overview-ruler markers. They leave text and terminal focus intact.
+Markers clear after 15 seconds, on pause/disconnect, or while buffers are dirty.
+Saved edits retain workspace-wide attribution; an edit marker does not claim
+that a specific agent made the change. Only the latest followed location is marked.
+
+## Verification
+
+Run `go test -race ./...`, `go vet ./...`, `go build ./...`, and `npm test` from
+`extensions/vscode`. To exercise an actual editor host, use a disposable Git
+project and an isolated editor user-data/extensions directory, then launch:
+
+```sh
+code /tmp/stvena-editor-project \
+  --user-data-dir /tmp/stvena-editor-profile \
+  --extensions-dir /tmp/stvena-editor-extensions \
+  --disable-workspace-trust \
+  --extensionDevelopmentPath=/absolute/path/to/stvena/extensions/vscode \
+  --extensionTestsPath=/absolute/path/to/stvena/extensions/vscode/test/host.js
+```
+
+The host smoke test writes only to that disposable workspace. It checks automatic
+source opening and line selection, reads without saved changes, read expiry,
+pause/resume, addition/deletion handling,
+unsaved buffer preservation, and the absence of diff tabs. Use the editor's equivalent CLI to validate a VS Code
+fork. Passing the protocol tests alone does not establish editor compatibility.
+
+On 2026-09-10, the original saved-edit smoke test passed in stock VS Code
+1.137.0 (Apple Silicon) and Antigravity IDE (VS Code base 1.107.0) on macOS.
+The expanded read/range/pause/expiry smoke test passed in Antigravity. Its
+activity inputs are protocol fixtures; live model-driven hook execution remains
+unverified. Other forks and remote editor hosts remain unverified.
+
+For v0.2.0-preview.1, the packaged Stvena Live 0.2.0 VSIX was extracted and tested
+in fresh, isolated VS Code and Antigravity profiles on macOS. Both passed the
+expanded host suite: edits, reads, ranges, pause/resume, expiry, unsaved-buffer
+preservation, and no diff tabs. The Go race suite, vet/build checks, and extension
+unit tests also passed locally. One initial clipboard-fixture test timed out;
+the full race suite passed on rerun.

--- a/docs/preview-release.md
+++ b/docs/preview-release.md
@@ -1,0 +1,66 @@
+# Stvena v0.2.0-preview.1 — VS Code and Antigravity preview
+
+This preview pairs Stvena's terminal workspace with the Stvena Live extension.
+Saved file changes open at their source location while keyboard focus stays in
+the integrated terminal. The extension includes pause/resume, an activity list,
+and temporary read/edit line markers.
+
+## Install
+
+Requires macOS or Linux, Git, VS Code or Antigravity, and an installed,
+authenticated agent CLI such as Codex or Claude Code.
+
+1. Install the preview binary:
+
+   ```sh
+   curl -fsSL https://raw.githubusercontent.com/nccapo/stvena/v0.2.0-preview.1/install.sh | \
+     STVENA_VERSION=v0.2.0-preview.1 sh
+   ```
+
+   Alternatively, download and extract the archive matching your system:
+
+   | System | Asset |
+   | --- | --- |
+   | macOS, Apple Silicon | `stvena_darwin_arm64.tar.gz` |
+   | macOS, Intel | `stvena_darwin_amd64.tar.gz` |
+   | Linux, ARM64 | `stvena_linux_arm64.tar.gz` |
+   | Linux, Intel/AMD 64-bit | `stvena_linux_amd64.tar.gz` |
+
+   Put the extracted `stvena` executable in a directory on your `PATH`.
+   The installer verifies the archive against `checksums.txt`; that file also
+   includes the VSIX checksum for manual verification.
+
+2. Download [stvena-live-0.2.0.vsix](https://github.com/nccapo/stvena/releases/download/v0.2.0-preview.1/stvena-live-0.2.0.vsix).
+   In VS Code or Antigravity's Command Palette, run
+   **Extensions: Install from VSIX…** and choose the downloaded file.
+
+3. Open a trusted local Git project. In its integrated terminal, run
+   `stvena --version` and confirm `0.2.0-preview.1`, then run `stvena`.
+   Ask the agent to edit and save a file. Stvena Live should navigate to the
+   change while you continue typing in the terminal.
+
+No Go or Node.js installation is needed. The ordinary installer continues to
+select the stable version; previews require the explicit version above.
+Extension updates are manual during this preview.
+
+## Preview scope
+
+- Local macOS and Linux are supported targets; native Windows is unsupported.
+  Remote extension hosts and other editor forks remain unverified.
+- Saved edits are sampled snapshots from every workspace writer, including you
+  and formatters. Intermediate writes can coalesce; edits have no agent attribution.
+- Read markers require supported agent hooks and any required hook trust.
+  Live model-driven hook execution remains unverified; saved-edit following
+  works independently. Read locations describe tool inputs, not model attention.
+- Automatic following skips unsaved buffers and deleted files. Use one Stvena
+  process per repository.
+- The bridge is local, with no listening network service or telemetry.
+
+If the extension stays **Waiting**, check the binary version, workspace trust,
+and that Stvena runs in that workspace. See **Stvena Live** in the Output panel
+for errors and the [extension guide](https://github.com/nccapo/stvena/blob/v0.2.0-preview.1/extensions/vscode/README.md)
+for hook setup and detailed limits.
+
+Report problems through [GitHub Issues](https://github.com/nccapo/stvena/issues)
+with your OS, editor version, Stvena version, agent CLI version, and reproduction
+steps. Remove private project content from any logs or screenshots.

--- a/extensions/vscode/.vscodeignore
+++ b/extensions/vscode/.vscodeignore
@@ -1,0 +1,5 @@
+test/**
+node_modules/**
+package-lock.json
+*.vsix
+.vscodeignore

--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 0.2.0
+
+First GitHub preview, paired with Stvena v0.2.0-preview.1.
+
+- Follow saved edits in VS Code and Antigravity while terminal focus stays put.
+- Show reported agent reads with blue markers and captured edits with amber markers.
+- Pause/resume following and inspect the latest activity from Explorer.
+- Preserve unsaved buffers and support nested Git folders and worktrees.
+
+Install the binary and VSIX from the same preview release. Other editor forks,
+remote workspaces, and live model-driven read hook execution remain unverified.

--- a/extensions/vscode/LICENSE
+++ b/extensions/vscode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Stvena contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -1,0 +1,145 @@
+# Stvena Live
+
+Run Stvena in your editor's integrated terminal and follow agent reads and saved
+edits in the actual source file, while keyboard focus stays in the terminal.
+Blue eye markers identify reported read ranges; amber pencil markers identify
+changed lines. Both include a line tint, an inline label, and a scrollbar marker.
+Markers expire after 15 seconds and clear on pause, disconnect, or unsaved edits.
+
+## Install the GitHub preview
+
+Requires Git, macOS or Linux, and VS Code or Antigravity. Install both parts from
+the [v0.2.0-preview.1 release](https://github.com/nccapo/stvena/releases/tag/v0.2.0-preview.1):
+
+1. Install the compatible Stvena binary:
+
+   ```sh
+   curl -fsSL https://raw.githubusercontent.com/nccapo/stvena/v0.2.0-preview.1/install.sh | \
+     STVENA_VERSION=v0.2.0-preview.1 sh
+   ```
+
+2. Download `stvena-live-0.2.0.vsix` from the same release. In either editor's
+   Command Palette, run **Extensions: Install from VSIX…** and select it.
+3. Open a trusted local Git project. In the integrated terminal, check
+   `stvena --version` reports `0.2.0-preview.1`, then run `stvena`.
+4. Ask your agent to edit and save a file. **Stvena Live** in Explorer lists the
+   captured edit and opens its source location while focus stays in the terminal.
+
+No Go or Node.js installation is needed. Use the version above explicitly:
+the default installer selects the stable release, which predates this bridge.
+Preview VSIX updates are manual: download and install the next release's VSIX.
+
+If the view stays **Waiting**, check the binary version, workspace trust, and
+that Stvena is running in the same Git project. Use **Stvena Live** in the Output
+panel for connection errors. Read markers depend on supported agent hooks;
+saved-edit following works independently of them.
+
+## Build from source
+
+1. Build the accompanying Stvena binary from this repository:
+   `go build -o bin/stvena ./cmd/stvena`.
+2. In `extensions/vscode`, run `npm ci` and `npm run package`.
+3. In VS Code, run **Extensions: Install from VSIX…** and select the generated
+   `stvena-live-0.2.0.vsix`.
+4. Open a Git project and run the newly built Stvena binary in its terminal.
+   Released binaries predating this integration do not publish editor updates.
+5. Ask your agent to edit a file. **Stvena Live** in Explorer lists the latest
+   captured batch; selecting a file opens its working source at the changed line.
+
+Click **Stvena: Following** in the status bar to pause automatic navigation.
+Navigation pauses while the activity list and saved source continue updating.
+Click again to resume. **Stvena: Show Latest Activity** opens the latest read or changed file.
+Automatic following skips unsaved buffers so their content and cursor stay intact.
+
+## Following reads
+
+Stvena adds a `PostToolUse` observer to standard `stvena codex` and `stvena claude`
+launches, including new agent terminals. Rebuild Stvena as well as the extension.
+For Codex versions with hooks, open `/hooks` and review/trust the Stvena observer
+when prompted. Stvena does not bypass hook trust or tool permissions. Hooks must
+be enabled by the agent; managed restrictions, safe/bare modes, and older agent
+versions may prevent read reporting. Saved-edit following still works.
+
+Supported reads are Claude's `Read` tool (`file_path`, `offset`, `limit`) and
+simple, single-file shell commands: `sed -n '40,65p' file`, `head -n 25 file`,
+and `cat file`. Quoted paths are supported. Compound commands, pipes, shell
+expansions, search results, and custom tools are skipped rather than assigned
+an invented range. A read without an explicit end is labeled “range unavailable”
+and gets a marker at the starting line. Ranges describe the tool's requested
+input after it returns, not model attention or proof that every line was read.
+Long-running reads appear only on completion. Source may have changed since then.
+
+The latest read from any supported terminal in this Stvena session is shown,
+with the agent command name. Simultaneous activity can coalesce. Paths outside
+the repository (including symlink targets) are excluded. No conversation logs
+are scanned or copied.
+
+When launching Claude with your own `--settings`, Stvena preserves that option
+and does not inject another settings argument. Add this observer to your existing
+settings to enable reads (use the absolute path to the rebuilt binary):
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [{
+      "matcher": "Read|Bash",
+      "hooks": [{ "type": "command", "command": "'/absolute/path/to/stvena' editor-hook", "timeout": 2 }]
+    }]
+  }
+}
+```
+
+The hook is silent and only publishes activity when launched under Stvena.
+Agent integration follows the [Codex hooks](https://developers.openai.com/codex/hooks)
+and [Claude hooks](https://code.claude.com/docs/en/hooks) interfaces.
+
+## Scope and compatibility
+
+- Targets the VS Code extension API, version 1.85 or newer. Other editors must
+  support that API and VSIX installation; compatibility needs testing per editor.
+  The editor-host smoke test passed on macOS in stock VS Code 1.137.0 (Apple
+  Silicon) and Antigravity IDE (VS Code base 1.107.0): source navigation, line
+  selection, pause/resume, additions/deletions, and unsaved buffer preservation.
+  Other forks have not yet been exercised in an editor host.
+- Zed uses a separate extension API and cannot install this VSIX. See
+  [Zed's extension documentation](https://zed.dev/docs/extensions/developing-extensions).
+- Git and Stvena must run on the same machine as the workspace extension host.
+  Local macOS and Linux are the initial target. Remote hosts are unverified.
+  Stvena itself does not support native Windows.
+- Open a trusted local Git workspace. Nested folders, multiple workspace roots,
+  and Git worktrees are supported by repository discovery.
+- Edit updates are snapshots of **saved files**, sampled roughly every 700 ms plus
+  capture time; extension polling adds up to another 700 ms. This is not a stream
+  of the agent's keystrokes or an exact audit history. Multiple writes can combine
+  into one capture, and a slow/disconnected editor can skip intermediate captures.
+- All workspace writers appear, including you, formatters, and other agents.
+  Edits cannot yet be attributed to a particular agent. Files in a batch have Git
+  order, not a proven edit order; following prefers the current file if it changed.
+- Changed lines come from consecutive captures; the editor displays the current
+  working file, which may be newer. Preexisting edits are excluded from a new
+  session's first capture. The terminal retains cumulative session review.
+- Deleted files stay listed but do not open an editor. Renames follow the new path.
+- Binary edits stay listed without automatic text previews. Text blobs have a
+  16 MiB limit; oversized capture patches can report a capture error. Ignored
+  untracked files follow Stvena's capture rules.
+- Use one Stvena process per repository. The view reports waiting after a normal
+  shutdown, or after 30 seconds without a heartbeat following a crash/stall.
+
+## Local data
+
+The extension reads a private `stvena-live.json` descriptor inside the worktree's
+Git directory and opens working source files. There is no listening
+network service, account, or telemetry. Stvena's tool observer stores only the
+latest read location in its private session cache and includes it in the bridge.
+The extension neither
+writes source files nor runs terminal commands on the agent's behalf.
+
+For connection or preview errors, select **Stvena Live** in the Output panel.
+
+## Development
+
+`npm test` exercises activity validation, marker lifecycle, and real Git/worktree/blob reads.
+The extension is plain JavaScript with no runtime npm dependencies. Launch an
+extension development host with `--extensionDevelopmentPath=/absolute/path/to/extensions/vscode`.
+See [the bridge protocol](../../docs/editor-integration.md) for integration details
+and the editor-host smoke test procedure.

--- a/extensions/vscode/media/edit.svg
+++ b/extensions/vscode/media/edit.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="#cca700" d="m11 1 4 4-9 9-5 1 1-5zm-8 10-.5 2.5L5 13l7-7-2-2z"/></svg>

--- a/extensions/vscode/media/read.svg
+++ b/extensions/vscode/media/read.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="#3794ff" d="M1 8s2-5 7-5 7 5 7 5-2 5-7 5-7-5-7-5zm2 0s2 3 5 3 5-3 5-3-2-3-5-3-5 3-5 3z"/><circle cx="8" cy="8" r="2" fill="#3794ff"/></svg>

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,0 +1,3834 @@
+{
+  "name": "stvena-live",
+  "version": "0.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "stvena-live",
+      "version": "0.2.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vscode/vsce": "^3.9.2"
+      },
+      "engines": {
+        "vscode": "^1.85.0"
+      }
+    },
+    "node_modules/@azu/format-text": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@azu/format-text/-/format-text-1.0.2.tgz",
+      "integrity": "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@azu/style-format": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@azu/style-format/-/style-format-1.0.1.tgz",
+      "integrity": "sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==",
+      "dev": true,
+      "license": "WTFPL",
+      "dependencies": {
+        "@azu/format-text": "^1.0.1"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-fNAjWnA/nZ2jz31kxR/AqRaUT8ewHBw/WuBIosK0moMy1C9e5ValbDfFdIxJzVOOYaYkV/b2F1S4H/aHiqfVQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.11.0.tgz",
+      "integrity": "sha512-IUZydyTUkDnYdstOW9pFOOUQlBjAepK5teihDE3x6yxsPJs/hsAaaYpeGxdxrgtOiJbBKSjKW7MDk7AEhb4LRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.11.1.tgz",
+      "integrity": "sha512-2QygG2F76ZpMP2eMztiJvAiFMu71M9rDeU7vO/QKg5Css7MgM4frUOslFjhVjRhbGaCNPtz/S8M6y46/fFKVuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-process": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-process/-/core-process-1.0.0.tgz",
+      "integrity": "sha512-/shnJ+ooO8WPxDhPEeI/2oRQuubn16gZ6CvlbpWbEswZfzwI9tI/sMAHmF3x1LuQ9yZYXfLW3TjzGMLEC5blKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.25.0.tgz",
+      "integrity": "sha512-bMs8ekJLjX8wPV+9IPBges1SLPyuDtE9g5gLDWOpxzKcoOFQnpLGkbcT1tdw3FaAmDS1gnPmMmJ6y/T5B96kIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.4.0.tgz",
+      "integrity": "sha512-eGwxD0AtncrxeBM4tG8R55Pc3rdX1hNW2WibJAgYpCVA6E93mvvVH+LcssoVjOBrSKWS55yEIHsk0X8ctHmfOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.14.0.tgz",
+      "integrity": "sha512-9n2pWK61veAuN0V20t9lOuoV4CFMdyAZ1ygZzvBGk/pBBJRib/PjL9PLXa/aI2CcPpyHfqVsxxqLCYl6uZlfDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.2.tgz",
+      "integrity": "sha512-NXL2/pCJctLxgw8bvrwwgge743kEq8LBT+O1pmV0vyUwetzFPH9auP6jhkU/cgZCPPtWoewAe3ncaGCgPo07fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-process": "^1.0.0",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.5",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.4.0.tgz",
+      "integrity": "sha512-rbAE25KUfjU/s3XHUdJgceoCP5dEOpMx85J04kF+QMdta73XkuG9JGHHinch+XIoKpBdqljin+KqURpJriSzLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.21.0.tgz",
+      "integrity": "sha512-80OcuXDErmcEDAIH9pBtSqBsed2sPT/IWmbG3xHLoPMl5zc8TINd6SlJAbVSmN5huGa3xGAg5qR7VnpaIEK0Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.14.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.14.0.tgz",
+      "integrity": "sha512-A4rb55hI86Q9tBl/+jBj7TMz7iX2RFgQs/nExFzcAtoI/BFRVdaH5SL/MivrYD7qvweMpN8AgVvVMHV8UBYxew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.6.0.tgz",
+      "integrity": "sha512-uFY9NxrWHw8PwZx7gAX6PDn+9vdfS05+levc/kwkx77IkjfaldnQbbcQzzDIZ5Hq5Zdr6/z92oAIoRWKp6MnOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.13.0",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+      "version": "16.13.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.13.0.tgz",
+      "integrity": "sha512-rOAy0KUcyBbdwVJ+f3uPpthXatFLLZN+/KWAsTLzk1aB23Xl9DRmmXYwSvBFOZyXj4jUQQ5FKxxRkhAFW1fOow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@secretlint/config-creator": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-10.2.2.tgz",
+      "integrity": "sha512-BynOBe7Hn3LJjb3CqCHZjeNB09s/vgf0baBaHVw67w7gHF0d25c3ZsZ5+vv8TgwSchRdUCRrbbcq5i2B1fJ2QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/types": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/config-loader": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/config-loader/-/config-loader-10.2.2.tgz",
+      "integrity": "sha512-ndjjQNgLg4DIcMJp4iaRD6xb9ijWQZVbd9694Ol2IszBIbGPPkwZHzJYKICbTBmh6AH/pLr0CiCaWdGJU7RbpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/profiler": "^10.2.2",
+        "@secretlint/resolver": "^10.2.2",
+        "@secretlint/types": "^10.2.2",
+        "ajv": "^8.17.1",
+        "debug": "^4.4.1",
+        "rc-config-loader": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/core": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/core/-/core-10.2.2.tgz",
+      "integrity": "sha512-6rdwBwLP9+TO3rRjMVW1tX+lQeo5gBbxl1I5F8nh8bgGtKwdlCMhMKsBWzWg1ostxx/tIG7OjZI0/BxsP8bUgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/profiler": "^10.2.2",
+        "@secretlint/types": "^10.2.2",
+        "debug": "^4.4.1",
+        "structured-source": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/formatter": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/formatter/-/formatter-10.2.2.tgz",
+      "integrity": "sha512-10f/eKV+8YdGKNQmoDUD1QnYL7TzhI2kzyx95vsJKbEa8akzLAR5ZrWIZ3LbcMmBLzxlSQMMccRmi05yDQ5YDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/resolver": "^10.2.2",
+        "@secretlint/types": "^10.2.2",
+        "@textlint/linter-formatter": "^15.2.0",
+        "@textlint/module-interop": "^15.2.0",
+        "@textlint/types": "^15.2.0",
+        "chalk": "^5.4.1",
+        "debug": "^4.4.1",
+        "pluralize": "^8.0.0",
+        "strip-ansi": "^7.1.0",
+        "table": "^6.9.0",
+        "terminal-link": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/formatter/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@secretlint/node": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/node/-/node-10.2.2.tgz",
+      "integrity": "sha512-eZGJQgcg/3WRBwX1bRnss7RmHHK/YlP/l7zOQsrjexYt6l+JJa5YhUmHbuGXS94yW0++3YkEJp0kQGYhiw1DMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/config-loader": "^10.2.2",
+        "@secretlint/core": "^10.2.2",
+        "@secretlint/formatter": "^10.2.2",
+        "@secretlint/profiler": "^10.2.2",
+        "@secretlint/source-creator": "^10.2.2",
+        "@secretlint/types": "^10.2.2",
+        "debug": "^4.4.1",
+        "p-map": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/profiler": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-10.2.2.tgz",
+      "integrity": "sha512-qm9rWfkh/o8OvzMIfY8a5bCmgIniSpltbVlUVl983zDG1bUuQNd1/5lUEeWx5o/WJ99bXxS7yNI4/KIXfHexig==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@secretlint/resolver": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/resolver/-/resolver-10.2.2.tgz",
+      "integrity": "sha512-3md0cp12e+Ae5V+crPQYGd6aaO7ahw95s28OlULGyclyyUtf861UoRGS2prnUrKh7MZb23kdDOyGCYb9br5e4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@secretlint/secretlint-formatter-sarif": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-formatter-sarif/-/secretlint-formatter-sarif-10.2.2.tgz",
+      "integrity": "sha512-ojiF9TGRKJJw308DnYBucHxkpNovDNu1XvPh7IfUp0A12gzTtxuWDqdpuVezL7/IP8Ua7mp5/VkDMN9OLp1doQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-sarif-builder": "^3.2.0"
+      }
+    },
+    "node_modules/@secretlint/secretlint-rule-no-dotenv": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-no-dotenv/-/secretlint-rule-no-dotenv-10.2.2.tgz",
+      "integrity": "sha512-KJRbIShA9DVc5Va3yArtJ6QDzGjg3PRa1uYp9As4RsyKtKSSZjI64jVca57FZ8gbuk4em0/0Jq+uy6485wxIdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/types": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/secretlint-rule-preset-recommend": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-preset-recommend/-/secretlint-rule-preset-recommend-10.2.2.tgz",
+      "integrity": "sha512-K3jPqjva8bQndDKJqctnGfwuAxU2n9XNCPtbXVI5JvC7FnQiNg/yWlQPbMUlBXtBoBGFYp08A94m6fvtc9v+zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/source-creator": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/source-creator/-/source-creator-10.2.2.tgz",
+      "integrity": "sha512-h6I87xJfwfUTgQ7irWq7UTdq/Bm1RuQ/fYhA3dtTIAop5BwSFmZyrchph4WcoEvbN460BWKmk4RYSvPElIIvxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/types": "^10.2.2",
+        "istextorbinary": "^9.5.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/types": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/types/-/types-10.2.2.tgz",
+      "integrity": "sha512-Nqc90v4lWCXyakD6xNyNACBJNJ0tNCwj2WNk/7ivyacYHxiITVgmLUFXTBOeCdy79iz6HtN9Y31uw/jbLrdOAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@textlint/ast-node-types": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.8.0.tgz",
+      "integrity": "sha512-5CiH9COYmovWmExQgs7763DzX6Gy9zjkjJ7JxCC95wyTcjwQn/8poNF6fv3qzRlmx8CRRde8DHr9FcgAAiPzgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@textlint/linter-formatter": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.8.0.tgz",
+      "integrity": "sha512-+oU3A235NATv6Lzi4xa4kJ65PuNJlIxesaO4AvDhDWA9FWm7y4XKWaoQCW1esgaQQ6dwnUiFKArQ8TcJ86mC4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azu/format-text": "^1.0.2",
+        "@azu/style-format": "^1.0.1",
+        "@textlint/module-interop": "15.8.0",
+        "@textlint/resolver": "15.8.0",
+        "@textlint/types": "15.8.0",
+        "debug": "^4.4.3",
+        "js-yaml": "^4.3.0",
+        "lodash": "^4.18.1",
+        "pluralize": "^2.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "table": "^6.9.0",
+        "text-table": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      }
+    },
+    "node_modules/@textlint/linter-formatter/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@textlint/linter-formatter/node_modules/pluralize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-2.0.0.tgz",
+      "integrity": "sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@textlint/linter-formatter/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@textlint/module-interop": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.8.0.tgz",
+      "integrity": "sha512-rt+OR1WYGoLOY8HkA/aBPrqufF6yUUEsKEAh7XohTsT3lp9IyZFT6zOIbjul9P4FAzsmSPkcrYjVx3Bz/IUfkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@textlint/resolver": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.8.0.tgz",
+      "integrity": "sha512-E88tzfX3K8Jykk+38aJ9cy8RquD8ABVOPTO2rFEESq0wcg8x6/ypdAS8ZgR7OKiGqlRF0hkO/m5PbQwVfKM3VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@textlint/types": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.8.0.tgz",
+      "integrity": "sha512-Anhc6y5736YIsvqae0U6k0YmB2M/QVHkEeOv2aydAn/WIkdI69dCOiDbe3/+RagS3qstFTSFWJzNRA2lUjv19w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/ast-node-types": "15.8.0"
+      }
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/sarif": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
+      "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.9.tgz",
+      "integrity": "sha512-edSdeAqkdxBVzA1yL1LrLCml1YjyCVvPMtMqJpbF+6K609tHe8V6sQUzFQSGcYNhcuhOceZtjvN32+mpIth30A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@vscode/vsce": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.2.tgz",
+      "integrity": "sha512-XSxMosEEDO6vLxELAHVkwmhC0qe0ijZni2jB9Rcs8kQsW4lhTDQ/wMzmwFs/buotAWSnpmUp/dRWD2ufG3UYKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/identity": "^4.1.0",
+        "@secretlint/node": "^10.1.2",
+        "@secretlint/secretlint-formatter-sarif": "^10.1.2",
+        "@secretlint/secretlint-rule-no-dotenv": "^10.1.2",
+        "@secretlint/secretlint-rule-preset-recommend": "^10.1.2",
+        "@vscode/vsce-sign": "^2.0.0",
+        "azure-devops-node-api": "^12.5.0",
+        "chalk": "^4.1.2",
+        "cheerio": "^1.0.0-rc.9",
+        "cockatiel": "^3.1.2",
+        "commander": "^12.1.0",
+        "form-data": "^4.0.0",
+        "glob": "^13.0.6",
+        "hosted-git-info": "^4.0.2",
+        "jsonc-parser": "^3.2.0",
+        "leven": "^3.1.0",
+        "markdown-it": "^14.1.0",
+        "mime": "^1.3.4",
+        "minimatch": "^10.2.2",
+        "parse-semver": "^1.1.1",
+        "read": "^1.0.7",
+        "secretlint": "^10.1.2",
+        "semver": "^7.5.2",
+        "tmp": "^0.2.3",
+        "typed-rest-client": "^1.8.4",
+        "url-join": "^4.0.1",
+        "xml2js": "^0.5.0",
+        "yauzl": "^3.2.1",
+        "yazl": "^2.2.2"
+      },
+      "bin": {
+        "vsce": "vsce"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "keytar": "^7.7.0"
+      }
+    },
+    "node_modules/@vscode/vsce-sign": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign/-/vsce-sign-2.1.0.tgz",
+      "integrity": "sha512-9AQrqazrBgTgRSuwleLVXUrIUphY02/SFCh2TKYoLV/xifJAdblhdmEmw5gUrYSPQ3sRwNs9iyCMD14sATEE6g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optionalDependencies": {
+        "@vscode/vsce-sign-alpine-arm64": "2.0.6",
+        "@vscode/vsce-sign-alpine-x64": "2.0.6",
+        "@vscode/vsce-sign-darwin-arm64": "2.0.6",
+        "@vscode/vsce-sign-darwin-x64": "2.0.6",
+        "@vscode/vsce-sign-linux-arm": "2.0.6",
+        "@vscode/vsce-sign-linux-arm64": "2.0.6",
+        "@vscode/vsce-sign-linux-x64": "2.0.6",
+        "@vscode/vsce-sign-win32-arm64": "2.0.6",
+        "@vscode/vsce-sign-win32-x64": "2.0.6"
+      }
+    },
+    "node_modules/@vscode/vsce-sign-alpine-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz",
+      "integrity": "sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-alpine-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz",
+      "integrity": "sha512-YoAGlmdK39vKi9jA18i4ufBbd95OqGJxRvF3n6ZbCyziwy3O+JgOpIUPxv5tjeO6gQfx29qBivQ8ZZTUF2Ba0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.6.tgz",
+      "integrity": "sha512-5HMHaJRIQuozm/XQIiJiA0W9uhdblwwl2ZNDSSAeXGO9YhB9MH5C4KIHOmvyjUnKy4UCuiP43VKpIxW1VWP4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz",
+      "integrity": "sha512-25GsUbTAiNfHSuRItoQafXOIpxlYj+IXb4/qarrXu7kmbH94jlm5sdWSCKrrREs8+GsXF1b+l3OB7VJy5jsykw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz",
+      "integrity": "sha512-UndEc2Xlq4HsuMPnwu7420uqceXjs4yb5W8E2/UkaHBB9OWCwMd3/bRe/1eLe3D8kPpxzcaeTyXiK3RdzS/1CA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz",
+      "integrity": "sha512-cfb1qK7lygtMa4NUl2582nP7aliLYuDEVpAbXJMkDq1qE+olIw/es+C8j1LJwvcRq1I2yWGtSn3EkDp9Dq5FdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.6.tgz",
+      "integrity": "sha512-/olerl1A4sOqdP+hjvJ1sbQjKN07Y3DVnxO4gnbn/ahtQvFrdhUi0G1VsZXDNjfqmXw57DmPi5ASnj/8PGZhAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz",
+      "integrity": "sha512-ivM/MiGIY0PJNZBoGtlRBM/xDpwbdlCWomUWuLmIxbi1Cxe/1nooYrEQoaHD8ojVRgzdQEUzMsRbyF5cJJgYOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz",
+      "integrity": "sha512-mgth9Kvze+u8CruYMmhHw6Zgy3GRX2S+Ed5oSokDEK5vPEwGGKnmuXua9tmFhomeAnhgJnL4DCna3TiNuGrBTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/azure-devops-node-api": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
+      "integrity": "sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/binaryextensions": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-6.11.0.tgz",
+      "integrity": "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==",
+      "dev": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "editions": "^6.21.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/boundary": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
+      "integrity": "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/cockatiel": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.2.1.tgz",
+      "integrity": "sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+      "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/editions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-6.22.0.tgz",
+      "integrity": "sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==",
+      "dev": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "version-range": "^4.15.0"
+      },
+      "engines": {
+        "ecmascript": ">= es5",
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.3.tgz",
+      "integrity": "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fs-extra": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globby": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.3",
+        "path-type": "^6.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/ignore": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.9.tgz",
+      "integrity": "sha512-brTTsvFRt5C1gGHtPst/281UjPD5t9fBqbgoMPlVWy11ZLTPfu7HxK4ZYqO9H7o/yC9rSTCI85EaQ4OoY12qYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istextorbinary": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-9.5.0.tgz",
+      "integrity": "sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==",
+      "dev": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "binaryextensions": "^6.11.0",
+        "editions": "^6.21.0",
+        "textextensions": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/keytar": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
+      "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.0.1"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.1.tgz",
+      "integrity": "sha512-4Ej49aYTDFIQ+uBkfX8GBvJGccoARxxPep+7aWTs55ozbjQJpW9M26Fe53vnGgvLeVzva/amzjQQaQu9w0vMhA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-abi": {
+      "version": "3.96.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+      "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-sarif-builder": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.4.0.tgz",
+      "integrity": "sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sarif": "^2.1.7",
+        "fs-extra": "^11.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.7.tgz",
+      "integrity": "sha512-VaWRu2i4FJNRtiRWCuuQRgfQ1B7a6+gMSrO+3j0EQi/k0ULfS9kosRxGoiqwzIjZTDI02tGfk5mXXltLg6QtfQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-semver": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
+      "integrity": "sha512-Eg1OuNntBMH0ojvEKSrvDSnwLmvVuUOSdylH/pSCPNMIspLlweJyIWXCE+k/5hm3cj/EBUYwmWkjhBALNP4LXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^5.1.0"
+      }
+    },
+    "node_modules/parse-semver/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc-config-loader": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.4.tgz",
+      "integrity": "sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "js-yaml": "^4.1.1",
+        "json5": "^2.2.3",
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.3",
+        "normalize-package-data": "^6.0.0",
+        "parse-json": "^8.0.0",
+        "type-fest": "^4.6.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/unicorn-magic": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/secretlint": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/secretlint/-/secretlint-10.2.2.tgz",
+      "integrity": "sha512-xVpkeHV/aoWe4vP4TansF622nBEImzCY73y/0042DuJ29iKIaqgoJ8fGxre3rVSHHbxar4FdJobmTnLp9AU0eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/config-creator": "^10.2.2",
+        "@secretlint/formatter": "^10.2.2",
+        "@secretlint/node": "^10.2.2",
+        "@secretlint/profiler": "^10.2.2",
+        "debug": "^4.4.1",
+        "globby": "^14.1.0",
+        "read-pkg": "^9.0.1"
+      },
+      "bin": {
+        "secretlint": "bin/secretlint.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/structured-source": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
+      "integrity": "sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boundary": "^2.0.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/terminal-link": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-4.0.0.tgz",
+      "integrity": "sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "supports-hyperlinks": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/textextensions": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-6.11.0.tgz",
+      "integrity": "sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==",
+      "dev": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "editions": "^6.21.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
+      "integrity": "sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/version-range": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/version-range/-/version-range-4.15.0.tgz",
+      "integrity": "sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==",
+      "dev": true,
+      "license": "Artistic-2.0",
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3"
+      }
+    }
+  }
+}

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,0 +1,113 @@
+{
+  "name": "stvena-live",
+  "displayName": "Stvena Live",
+  "description": "Follow agent reads and edits with live source navigation and line highlights.",
+  "version": "0.2.0",
+  "publisher": "nccapo",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nccapo/stvena.git",
+    "directory": "extensions/vscode"
+  },
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "main": "./src/extension.js",
+  "extensionKind": [
+    "workspace"
+  ],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": false
+    },
+    "virtualWorkspaces": {
+      "supported": false
+    }
+  },
+  "scripts": {
+    "test": "node --test test/*.test.js",
+    "package": "vsce package --no-dependencies --baseContentUrl https://github.com/nccapo/stvena/blob/${STVENA_SOURCE_REF:-main}/extensions/vscode --baseImagesUrl https://raw.githubusercontent.com/nccapo/stvena/${STVENA_SOURCE_REF:-main}/extensions/vscode"
+  },
+  "contributes": {
+    "commands": [
+      {
+        "command": "stvena.toggleFollow",
+        "title": "Stvena: Pause / Resume Following",
+        "icon": "$(debug-pause)"
+      },
+      {
+        "command": "stvena.showLatest",
+        "title": "Stvena: Show Latest Activity",
+        "icon": "$(go-to-file)"
+      },
+      {
+        "command": "stvena.openChange",
+        "title": "Stvena: Open Captured Edit"
+      }
+    ],
+    "views": {
+      "explorer": [
+        {
+          "id": "stvena.changes",
+          "name": "Stvena Live"
+        }
+      ]
+    },
+    "viewsWelcome": [
+      {
+        "view": "stvena.changes",
+        "contents": "Run **stvena** in this project's terminal. Reported reads and captured edits will appear here.\n[Show latest activity](command:stvena.showLatest)"
+      }
+    ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "stvena.toggleFollow",
+          "when": "view == stvena.changes",
+          "group": "navigation"
+        },
+        {
+          "command": "stvena.showLatest",
+          "when": "view == stvena.changes",
+          "group": "navigation"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "stvena.openChange",
+          "when": "false"
+        }
+      ]
+    },
+    "colors": [
+      {
+        "id": "stvena.readBackground",
+        "description": "Background of the latest agent read range.",
+        "defaults": {
+          "dark": "#3794ff20",
+          "light": "#007acc18",
+          "highContrast": "#3794ff30"
+        }
+      },
+      {
+        "id": "stvena.editBackground",
+        "description": "Background of the latest captured edit range.",
+        "defaults": {
+          "dark": "#cca70020",
+          "light": "#b8950018",
+          "highContrast": "#cca70030"
+        }
+      }
+    ]
+  },
+  "devDependencies": {
+    "@vscode/vsce": "^3.9.2"
+  }
+}

--- a/extensions/vscode/src/activity.js
+++ b/extensions/vscode/src/activity.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const lifetime = 15000;
+function fresh(time, now = Date.now()) {
+  const age = now - Date.parse(time);
+  return age >= 0 && age < lifetime;
+}
+function readRow(repo) {
+  const activity = repo.state?.activity;
+  if (!activity || !fresh(activity.updatedAt)) return undefined;
+  return { repo, kind: 'read', at: activity.updatedAt, id: activity.id, agent: activity.agent,
+    file: { path: activity.path, line: activity.line,
+      ranges: activity.endLine ? [{ start: activity.line, end: activity.endLine }] : [] } };
+}
+function editRows(repo) {
+  return repo.state.files.map(file => ({ repo, file, kind: 'edit', at: repo.state.changedAt }));
+}
+function label(row) {
+  if (row.kind === 'read') {
+    const range = row.file.ranges[0];
+    return `${row.agent || 'Agent'} · Read ${range ? `lines ${range.start}–${range.end}` : 'file (range unavailable)'}`;
+  }
+  return 'Changed · latest captured edit';
+}
+
+// Decorations are separate from editor selection, so the activity remains visible
+// with keyboard focus in the terminal. Only the currently followed location is marked.
+function createMarkers(vscode, context) {
+  const types = {};
+  for (const [kind, color] of [['read', 'editorInfo.foreground'], ['edit', 'editorWarning.foreground']]) {
+    types[kind] = vscode.window.createTextEditorDecorationType({
+      isWholeLine: true, rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
+      backgroundColor: new vscode.ThemeColor(kind === 'read' ? 'stvena.readBackground' : 'stvena.editBackground'),
+      borderWidth: '0 0 0 2px', borderStyle: 'solid', borderColor: new vscode.ThemeColor(color),
+      overviewRulerColor: new vscode.ThemeColor(color), overviewRulerLane: vscode.OverviewRulerLane.Right,
+      gutterIconPath: vscode.Uri.file(context.asAbsolutePath(`media/${kind}.svg`)), gutterIconSize: 'contain',
+    });
+    context.subscriptions.push(types[kind]);
+  }
+  let current;
+  function paint() {
+    for (const editor of vscode.window.visibleTextEditors) {
+      for (const type of Object.values(types)) editor.setDecorations(type, []);
+      if (!current || editor.document.isDirty || editor.document.uri.toString() !== current.uri || !fresh(current.row.at)) continue;
+      const row = current.row;
+      // An unknown read range gets a marker at its reported starting line only.
+      const ranges = row.file.ranges?.length ? row.file.ranges : [{ start: row.file.line, end: row.file.line }];
+      const options = ranges.map((range, index) => {
+        const start = Math.min(range.start - 1, editor.document.lineCount - 1);
+        const end = Math.min(range.end - 1, editor.document.lineCount - 1);
+        return { range: new vscode.Range(start, 0, end, editor.document.lineAt(end).text.length),
+          hoverMessage: label(row),
+          ...(index === 0 ? { renderOptions: { after: { contentText: `  ${label(row)}`, margin: '0 0 0 1em',
+            color: new vscode.ThemeColor(row.kind === 'read' ? 'editorInfo.foreground' : 'editorWarning.foreground') } } } : {}) };
+      });
+      editor.setDecorations(types[row.kind || 'edit'], options);
+    }
+  }
+  return {
+    show(row, uri) { current = { row, uri: uri.toString() }; paint(); },
+    refresh(isLive) { if (current && !isLive(current.row)) current = undefined; paint(); },
+    clear() { current = undefined; paint(); },
+  };
+}
+module.exports = { fresh, readRow, editRows, label, createMarkers };

--- a/extensions/vscode/src/bridge.js
+++ b/extensions/vscode/src/bridge.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const { execFile } = require('node:child_process');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const { promisify } = require('node:util');
+const exec = promisify(execFile);
+const oidPattern = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
+
+async function git(root, ...args) {
+  const { stdout } = await exec('git', ['--no-optional-locks', '-C', root, ...args], {
+    encoding: 'buffer', timeout: 5000, maxBuffer: 16 * 1024 * 1024, windowsHide: true,
+  });
+  return stdout;
+}
+
+async function discover(folder) {
+  const root = (await git(folder, 'rev-parse', '--show-toplevel')).toString().replace(/\n$/, '');
+  const gitDir = (await git(root, 'rev-parse', '--absolute-git-dir')).toString().replace(/\n$/, '');
+  return { root, statePath: path.join(gitDir, 'stvena-live.json') };
+}
+
+function validPath(value) {
+  return typeof value === 'string' && value.length > 0 && !value.includes('\0') &&
+    !path.posix.isAbsolute(value) && !path.win32.isAbsolute(value) &&
+    !value.split(/[\\/]/).includes('..');
+}
+
+function parseState(data) {
+  const state = JSON.parse(data);
+  if (state.version !== 1 || typeof state.session !== 'string' || !state.session ||
+      !Number.isSafeInteger(state.sequence) || state.sequence < 0 ||
+      typeof state.active !== 'boolean' || typeof state.updatedAt !== 'string' ||
+      !Number.isFinite(Date.parse(state.updatedAt)) ||
+      (state.error !== undefined && typeof state.error !== 'string') || !Array.isArray(state.files)) {
+    throw new Error('Unsupported or invalid Stvena live state; update Stvena and the extension together.');
+  }
+  for (const file of state.files) {
+    if (!validPath(file.path) || (file.oldPath !== undefined && !validPath(file.oldPath)) ||
+        typeof file.before !== 'string' || !oidPattern.test(file.before) ||
+        typeof file.after !== 'string' || !oidPattern.test(file.after) ||
+        !Number.isSafeInteger(file.line) || file.line < 1 ||
+        typeof file.status !== 'string' || !/^[AMDRCTU?]$/.test(file.status) ||
+        !Number.isSafeInteger(file.added) || file.added < 0 ||
+        !Number.isSafeInteger(file.deleted) || file.deleted < 0 ||
+        typeof file.binary !== 'boolean' || typeof file.truncated !== 'boolean') {
+      throw new Error('Invalid captured edit in Stvena live state.');
+    }
+    if (file.ranges !== undefined && (!Array.isArray(file.ranges) || file.ranges.some(range =>
+      !range || !Number.isSafeInteger(range.start) || range.start < 1 ||
+      !Number.isSafeInteger(range.end) || range.end < range.start))) {
+      throw new Error('Invalid changed line ranges.');
+    }
+  }
+  if (state.changedAt !== undefined && !Number.isFinite(Date.parse(state.changedAt))) throw new Error('Invalid edit timestamp.');
+  const activity = state.activity;
+  if (activity !== undefined && (!activity || activity.session !== state.session ||
+      typeof activity.id !== 'string' || !activity.id || typeof activity.agent !== 'string' ||
+      !validPath(activity.path) || !Number.isSafeInteger(activity.line) || activity.line < 1 ||
+      (activity.endLine !== undefined && (!Number.isSafeInteger(activity.endLine) || activity.endLine < activity.line)) ||
+      typeof activity.updatedAt !== 'string' || !Number.isFinite(Date.parse(activity.updatedAt)))) {
+    throw new Error('Invalid agent read activity.');
+  }
+  return state;
+}
+
+async function readState(repo) {
+  try {
+    // Reject oversized metadata before parsing it. Source stays in Git objects.
+    const file = await fs.open(repo.statePath, 'r');
+    try {
+      if ((await file.stat()).size > 8 * 1024 * 1024) throw new Error('Stvena live state exceeds 8 MiB.');
+      return parseState(await file.readFile('utf8'));
+    } finally {
+      await file.close();
+    }
+  } catch (error) {
+    if (error.code === 'ENOENT') return undefined;
+    throw error;
+  }
+}
+
+function isLive(state, now = Date.now()) {
+  return !!state && state.active && now - Date.parse(state.updatedAt) < 30000;
+}
+
+async function readBlob(root, oid) {
+  if (typeof oid !== 'string' || !oidPattern.test(oid)) throw new Error('Invalid captured object.');
+  if (/^0+$/.test(oid)) return '';
+  const data = await git(root, 'cat-file', 'blob', oid);
+  if (data.includes(0)) throw new Error('Binary content has no text preview.');
+  return data.toString('utf8');
+}
+
+module.exports = { discover, readState, parseState, isLive, readBlob };

--- a/extensions/vscode/src/extension.js
+++ b/extensions/vscode/src/extension.js
@@ -1,0 +1,176 @@
+'use strict';
+
+const vscode = require('vscode');
+const path = require('node:path');
+const bridge = require('./bridge');
+const activity = require('./activity');
+
+function activate(context) {
+  if (!vscode.workspace.isTrusted) return;
+  let repos = [], rows = [], latest, following = true, disposed = false, busy = false;
+  let discoveryAt = 0, generation = 0, displayed;
+  const seen = new Map();
+  const errors = new Map();
+  const markers = activity.createMarkers(vscode, context);
+  const changes = new vscode.EventEmitter();
+  const output = vscode.window.createOutputChannel('Stvena Live');
+  const tree = vscode.window.createTreeView('stvena.changes', { treeDataProvider: {
+    onDidChangeTreeData: changes.event,
+    getChildren: () => rows,
+    getTreeItem: row => {
+      const item = new vscode.TreeItem(row.file.path);
+      item.description = row.kind === 'read' ? activity.label(row) : `${row.file.status} +${row.file.added} −${row.file.deleted} · ${path.basename(row.repo.root)}`;
+      item.tooltip = `${row.file.oldPath ? row.file.oldPath + ' → ' : ''}${row.file.path}\nLine ${row.file.line} · ${activity.label(row)}`;
+      item.iconPath = new vscode.ThemeIcon(row.kind === 'read' ? 'eye' : row.file.binary ? 'file-binary' : 'file-code');
+      item.command = { command: 'stvena.openChange', title: 'Open edit', arguments: [row] };
+      return item;
+    },
+  } });
+  const status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 10);
+  status.command = 'stvena.toggleFollow';
+  status.show();
+
+  function report(key, error) {
+    const message = error.message || String(error);
+    if (errors.get(key) !== message) output.appendLine(`${key}: ${message}`);
+    errors.set(key, message);
+  }
+
+  function updateStatus() {
+    const live = repos.filter(repo => bridge.isLive(repo.state));
+    const failed = live.some(repo => repo.state.error) || errors.size > 0;
+    status.text = `$(pulse) Stvena: ${!following ? 'Paused' : failed ? 'Waiting for capture' : live.length ? 'Following' : 'Waiting'}`;
+    status.tooltip = `${latest && activity.fresh(latest.at) ? `${activity.label(latest)} · ${latest.file.path}\n` : ''}Click to pause/resume following. Run stvena in the project terminal. Open Stvena Live output for connection errors.`;
+    tree.message = failed ? 'Capture unavailable. See Stvena Live output.' :
+      !live.length ? 'Waiting for stvena in this workspace.' :
+      !following ? 'Following paused. Select any captured edit to inspect it.' :
+      latest && activity.fresh(latest.at) ? `${activity.label(latest)} · ${latest.file.path}` :
+      'Following reads and edits · waiting for activity';
+  }
+
+  async function show(row, automatic = false) {
+    if (!row || disposed) return;
+    if (row.file.binary || row.file.truncated) {
+      if (!automatic) await vscode.window.showInformationMessage('This captured edit has no complete text preview (binary or size limit).');
+      return;
+    }
+    if (/^0+$/.test(row.file.after)) {
+      if (!automatic) await vscode.window.showInformationMessage('This file was deleted; there is no working file to follow.');
+      return;
+    }
+    const ticket = ++generation;
+    try {
+      const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(row.repo.root, row.file.path)));
+      if (disposed || ticket !== generation || (automatic && !following)) return;
+      // An unsaved buffer may no longer match the captured line. Leave the user's
+      // edits and cursor alone until they save or explicitly choose this file.
+      if (automatic && doc.isDirty) return;
+      const line = Math.min(row.file.line - 1, doc.lineCount - 1);
+      const selection = new vscode.Range(line, 0, line, 0);
+      const editor = await vscode.window.showTextDocument(doc, {
+        preview: true, preserveFocus: automatic, selection,
+      });
+      if (disposed || ticket !== generation || (automatic && !following)) return;
+      editor.revealRange(selection, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+      displayed = row;
+      markers.show(row, doc.uri);
+      errors.delete('preview');
+    } catch (error) {
+      report('preview', error);
+      if (!automatic) await vscode.window.showErrorMessage(`Stvena: ${error.message}`);
+    }
+  }
+
+  async function poll() {
+    if (busy || disposed) return;
+    busy = true;
+    try {
+      if (Date.now() >= discoveryAt) {
+        discoveryAt = Date.now() + 5000;
+        const found = new Map();
+        for (const folder of vscode.workspace.workspaceFolders || []) {
+          if (folder.uri.scheme !== 'file') continue;
+          try {
+            const repo = await bridge.discover(folder.uri.fsPath);
+            found.set(repo.root, repos.find(old => old.root === repo.root) || repo);
+            errors.delete(folder.name);
+          } catch (error) {
+            // Non-Git folders are ordinary workspace members.
+            if (!String(error.stderr).includes('not a git repository')) report(folder.name, error);
+            else errors.delete(folder.name);
+          }
+        }
+        repos = [...found.values()];
+      }
+      let follow;
+      for (const repo of repos) {
+        try {
+          repo.state = await bridge.readState(repo);
+          if (!repo.state?.error) errors.delete(repo.root);
+          if (!bridge.isLive(repo.state) || repo.state.error) {
+            if (repo.state?.error) report(repo.root, new Error(repo.state.error));
+            continue;
+          }
+          const read = activity.readRow(repo);
+          const key = `${repo.state.session}:${repo.state.sequence}`;
+          const previous = seen.get(repo.root);
+          const readID = repo.state.activity?.id;
+          if (previous?.edit !== key || (read && previous?.read !== readID)) {
+            const files = activity.editRows(repo);
+            const followable = files.filter(row => !row.file.binary && !row.file.truncated && !/^0+$/.test(row.file.after));
+            const edit = followable.find(row =>
+              displayed?.repo.root === repo.root && displayed?.file.path === row.file.path) ||
+              followable[0];
+            let candidate = previous?.edit !== key ? edit : undefined;
+            if (read && previous?.read !== readID && (!candidate || Date.parse(read.at) >= (Date.parse(candidate.at) || 0))) candidate = read;
+            if (candidate && (!follow || (Date.parse(candidate.at) || 0) >= (Date.parse(follow.at) || 0))) follow = candidate;
+          }
+          seen.set(repo.root, { edit: key, read: readID });
+        } catch (error) {
+          repo.state = undefined;
+          report(repo.root, error);
+        }
+      }
+      if (disposed) return;
+      rows = repos.flatMap(repo => bridge.isLive(repo.state) && !repo.state.error ?
+        [activity.readRow(repo), ...activity.editRows(repo)].filter(Boolean) : []);
+      if (follow) latest = follow;
+      // Read expiry must clear the marker without jumping back to an old edit.
+      if (follow && !activity.fresh(follow.at) && follow.at) follow = undefined;
+      markers.refresh(row => rows.some(current => current.repo.root === row.repo.root &&
+        current.kind === row.kind && current.file.path === row.file.path && current.at === row.at && current.id === row.id));
+      changes.fire();
+      updateStatus();
+      if (following && follow) await show(follow, true);
+    } finally {
+      busy = false;
+    }
+  }
+
+  const timer = setInterval(() => void poll().catch(error => report('connection', error)), 700);
+  context.subscriptions.push(changes, output, tree, status,
+    vscode.window.onDidChangeVisibleTextEditors(() => markers.refresh(() => true)),
+    vscode.workspace.onDidChangeTextDocument(() => markers.refresh(() => true)),
+    vscode.workspace.onDidChangeWorkspaceFolders(() => { discoveryAt = 0; }),
+    vscode.commands.registerCommand('stvena.openChange', row => show(row)),
+    vscode.commands.registerCommand('stvena.showLatest', async () => {
+      if (latest && rows.some(row => row.repo.root === latest.repo.root &&
+        row.kind === latest.kind && row.id === latest.id && row.at === latest.at &&
+        row.file.path === latest.file.path && row.file.after === latest.file.after)) await show(latest);
+      else if (rows.length) await show(rows[0]);
+      else await vscode.window.showInformationMessage('Run stvena in this workspace and wait for a read or captured edit.');
+    }),
+    vscode.commands.registerCommand('stvena.toggleFollow', () => {
+      following = !following;
+      generation++;
+      if (!following) markers.clear();
+      updateStatus();
+      if (following && rows.length) return show(rows.find(row =>
+        row.repo.root === latest?.repo.root && row.kind === latest?.kind && row.id === latest?.id &&
+        row.file.path === latest?.file.path) || rows[0], true);
+    }),
+    { dispose() { disposed = true; generation++; clearInterval(timer); } });
+  void poll().catch(error => report('connection', error));
+}
+
+module.exports = { activate };

--- a/extensions/vscode/test/activity.test.js
+++ b/extensions/vscode/test/activity.test.js
@@ -1,0 +1,52 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { fresh, readRow, label, createMarkers } = require('../src/activity');
+const { parseState } = require('../src/bridge');
+
+test('read activity validates paths, ranges, session and freshness', () => {
+  const now = new Date().toISOString();
+  const state = { version: 1, session: 's', sequence: 0, active: true, updatedAt: now, files: [],
+    activity: { session: 's', id: 'read-1', agent: 'codex', path: 'a.go', line: 4, endLine: 8, updatedAt: now } };
+  assert.deepEqual(parseState(JSON.stringify(state)), state);
+  assert.equal(readRow({ state }).file.ranges[0].end, 8);
+  assert.match(label(readRow({ state })), /Read lines 4–8/);
+  assert.equal(fresh(now, Date.parse(now) + 15000), false);
+  assert.equal(fresh(now, Date.parse(now) - 1), false);
+  for (const change of [{ path: '../other' }, { path: '/other' }, { line: 0 }, { endLine: 3 },
+    { session: 'different' }, { id: '' }, { updatedAt: 'bad' }]) {
+    assert.throws(() => parseState(JSON.stringify({ ...state, activity: { ...state.activity, ...change } })));
+  }
+  state.activity.updatedAt = new Date(Date.now() - 16000).toISOString();
+  assert.equal(readRow({ state }), undefined);
+});
+
+test('read/edit markers cover reported ranges, clamp EOF, and clear on dirty, expiry and disconnect', () => {
+  let paints = new Map();
+  const editor = { document: { isDirty: false, uri: { toString: () => 'file:a.go' },
+    lineCount: 10, lineAt: () => ({ text: 'text' }) }, setDecorations: (type, options) => paints.set(type.kind, options) };
+  let next = 0;
+  const vscode = {
+    window: { visibleTextEditors: [editor], createTextEditorDecorationType: () => ({ kind: next++ }) },
+    DecorationRangeBehavior: { ClosedClosed: 1 }, OverviewRulerLane: { Right: 1 },
+    ThemeColor: class { constructor(id) { this.id = id; } }, Uri: { file: value => value },
+    Range: class { constructor(start, col, end, endCol) { Object.assign(this, { start, end, col, endCol }); } },
+  };
+  const markers = createMarkers(vscode, { subscriptions: [], asAbsolutePath: value => value });
+  const row = { kind: 'read', agent: 'codex', at: new Date().toISOString(), file: { line: 4, ranges: [{ start: 4, end: 100 }] } };
+  markers.show(row, editor.document.uri);
+  assert.equal(paints.get(0)[0].range.start, 3);
+  assert.equal(paints.get(0)[0].range.end, 9);
+  assert.match(paints.get(0)[0].renderOptions.after.contentText, /Read/);
+  editor.document.isDirty = true;
+  markers.refresh(() => true);
+  assert.deepEqual(paints.get(0), []);
+  editor.document.isDirty = false;
+  markers.show({ ...row, kind: 'edit', file: { line: 2, ranges: [{ start: 2, end: 3 }, { start: 8, end: 8 }] } }, editor.document.uri);
+  assert.equal(paints.get(1).length, 2);
+  assert.deepEqual(paints.get(0), []);
+  markers.refresh(() => false);
+  assert.deepEqual(paints.get(1), []);
+  markers.show({ ...row, at: new Date(Date.now() - 16000).toISOString() }, editor.document.uri);
+  assert.deepEqual(paints.get(0), []);
+});

--- a/extensions/vscode/test/bridge.test.js
+++ b/extensions/vscode/test/bridge.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { discover, parseState, readState, isLive, readBlob } = require('../src/bridge');
+
+const state = () => ({ version: 1, session: 'test-session', sequence: 1, active: true,
+  updatedAt: new Date().toISOString(), files: [{ path: 'nested/file.txt', status: 'M',
+    before: '1'.repeat(40), after: '2'.repeat(40), line: 4, added: 1, deleted: 1,
+    binary: false, truncated: false }] });
+
+test('state validation and heartbeat expiry', () => {
+  const value = state();
+  assert.deepEqual(parseState(JSON.stringify(value)), value);
+  assert.equal(isLive(value), true);
+  assert.equal(isLive(value, Date.parse(value.updatedAt) + 30001), false);
+  assert.equal(isLive({ ...value, active: false }), false);
+  for (const change of [{ version: 2 }, { sequence: -1 }, { updatedAt: 'invalid' }, { files: null }]) {
+    assert.throws(() => parseState(JSON.stringify({ ...value, ...change })));
+  }
+  for (const change of [{ path: '../outside' }, { path: '/outside' }, { path: 'C:\\outside' },
+    { oldPath: '../outside' }, { before: '--help' }, { line: 0 }, { binary: 'false' }]) {
+    assert.throws(() => parseState(JSON.stringify({ ...value, files: [{ ...value.files[0], ...change }] })));
+  }
+});
+
+test('discovers nested folders and worktrees; reads exact immutable blobs', async t => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'stvena-extension-'));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const git = (...args) => execFileSync('git', ['-C', root, ...args], { encoding: 'utf8' }).trim();
+  git('init', '-q');
+  git('config', 'user.name', 'Stvena Test');
+  git('config', 'user.email', 'test@example.invalid');
+  await fs.mkdir(path.join(root, 'nested'));
+  await fs.writeFile(path.join(root, 'nested/file.txt'), 'before\n');
+  git('add', '.');
+  git('commit', '-qm', 'baseline');
+  const oid = git('rev-parse', 'HEAD:nested/file.txt');
+  const repo = await discover(path.join(root, 'nested'));
+  assert.equal(await fs.realpath(repo.root), await fs.realpath(root));
+  assert.equal(await readState(repo), undefined);
+  const value = state();
+  value.files[0].before = oid;
+  await fs.writeFile(repo.statePath, JSON.stringify(value));
+  assert.deepEqual(await readState(repo), value);
+  await fs.writeFile(path.join(root, 'nested/file.txt'), 'after\n');
+  assert.equal(await readBlob(repo.root, oid), 'before\n');
+  assert.equal(await readBlob(repo.root, '0'.repeat(40)), '');
+  await assert.rejects(readBlob(repo.root, '--help'));
+  await fs.writeFile(path.join(root, 'binary'), Buffer.from([0, 1]));
+  const binary = git('hash-object', '-w', 'binary');
+  await assert.rejects(readBlob(repo.root, binary), /Binary/);
+  git('worktree', 'add', '-qb', 'test-worktree', path.join(root, 'worktree'));
+  const worktree = await discover(path.join(root, 'worktree'));
+  assert.notEqual(worktree.statePath, repo.statePath);
+  assert.equal(await readState(worktree), undefined);
+});

--- a/extensions/vscode/test/host.js
+++ b/extensions/vscode/test/host.js
@@ -1,0 +1,115 @@
+'use strict';
+
+// Run only in an isolated extension development host with a disposable workspace.
+const vscode = require('vscode');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { discover } = require('../src/bridge');
+
+async function run() {
+  const root = await fs.realpath(vscode.workspace.workspaceFolders[0].uri.fsPath);
+  // Avoid destructive fixture writes if someone launches the test in their repo.
+  assert.equal(path.basename(root), 'stvena-editor-project');
+  const git = (...args) => execFileSync('git', ['-C', root, ...args], { encoding: 'utf8' }).trim();
+  git('init', '-q');
+  const repo = await discover(root);
+  const blob = text => execFileSync('git', ['-C', root, 'hash-object', '-w', '--stdin'],
+    { input: text, encoding: 'utf8' }).trim();
+  const before = blob('one\ntwo\nthree\nold\n');
+  const after = blob('one\ntwo\nthree\nnew\n');
+  let sequence = 0, value;
+  async function writeState() {
+    value.updatedAt = new Date().toISOString();
+    await fs.writeFile(repo.statePath + '.tmp', JSON.stringify(value));
+    await fs.rename(repo.statePath + '.tmp', repo.statePath);
+  }
+  async function publish(before, after, file = 'example.txt') {
+    const target = path.join(root, file);
+    if (/^0+$/.test(after)) await fs.rm(target, { force: true });
+    else await fs.writeFile(target, git('cat-file', 'blob', after) + '\n');
+    value = { version: 1, session: 'editor-host-test', sequence: ++sequence,
+      active: true, changedAt: new Date().toISOString(), files: [{ path: file,
+        status: /^0+$/.test(before) ? 'A' : /^0+$/.test(after) ? 'D' : 'M',
+        before, after, line: 4, ranges: [{ start: 4, end: 4 }], added: 1, deleted: 1, binary: false, truncated: false }] };
+    await writeState();
+  }
+  async function waitFor(predicate, message) {
+    const deadline = Date.now() + 12000;
+    while (Date.now() < deadline) {
+      if (predicate()) return;
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    throw new Error(message);
+  }
+  const visible = file => vscode.window.visibleTextEditors.find(editor =>
+    editor.document.uri.scheme === 'file' && editor.document.uri.fsPath === path.join(root, file));
+  const noDiffs = () => assert.ok(!vscode.window.tabGroups.all.flatMap(group => group.tabs)
+    .some(tab => tab.input instanceof vscode.TabInputTextDiff), 'Following opened a diff tab');
+  await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+  await vscode.extensions.getExtension('nccapo.stvena-live').activate();
+  try {
+    await publish(before, after);
+    await waitFor(() => visible('example.txt'), 'Automatic source navigation did not open');
+    assert.equal(visible('example.txt').document.getText(), 'one\ntwo\nthree\nnew\n');
+    assert.equal(visible('example.txt').selection.active.line, 3);
+    noDiffs();
+
+    await vscode.commands.executeCommand('stvena.toggleFollow');
+    const next = blob('one\ntwo\nthree\nnewer\n');
+    await publish(after, next, 'next.txt');
+    await new Promise(resolve => setTimeout(resolve, 1800));
+    assert.ok(visible('example.txt'), 'Pause navigated away from the current file');
+    assert.equal(visible('next.txt'), undefined);
+    await vscode.commands.executeCommand('stvena.toggleFollow');
+    await waitFor(() => visible('next.txt'), 'Resume did not show the newest file');
+    assert.equal(visible('next.txt').selection.active.line, 3);
+
+    const empty = '0'.repeat(40);
+    await publish(empty, next, 'added.txt');
+    await waitFor(() => visible('added.txt'), 'Addition did not open the working file');
+    await publish(next, empty, 'added.txt');
+    await new Promise(resolve => setTimeout(resolve, 1800));
+    noDiffs();
+
+    // Automatic following must not replace an unsaved buffer or move its cursor.
+    await vscode.commands.executeCommand('stvena.toggleFollow');
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(root, 'example.txt')));
+    const editor = await vscode.window.showTextDocument(doc);
+    await editor.edit(edit => edit.insert(new vscode.Position(0, 0), 'unsaved '));
+    editor.selection = new vscode.Selection(0, 0, 0, 0);
+    const unsaved = doc.getText();
+    await publish(after, next);
+    await new Promise(resolve => setTimeout(resolve, 1800));
+    await vscode.commands.executeCommand('stvena.toggleFollow');
+    assert.equal(doc.getText(), unsaved);
+    assert.equal(editor.selection.active.line, 0);
+    assert.ok(doc.isDirty);
+    noDiffs();
+    await vscode.commands.executeCommand('workbench.action.revertAndCloseActiveEditor');
+    // Reads must navigate even when no saved file or capture sequence changes.
+    await fs.writeFile(path.join(root, 'reading.txt'), 'a\nb\nc\nd\ne\nf\n');
+    value.activity = { session: value.session, id: 'read-1', agent: 'codex', path: 'reading.txt',
+      line: 2, endLine: 4, updatedAt: new Date().toISOString() };
+    await writeState();
+    await waitFor(() => visible('reading.txt')?.selection.active.line === 1, 'Read did not follow file/range');
+    await vscode.commands.executeCommand('stvena.toggleFollow');
+    value.activity = { ...value.activity, id: 'read-2', line: 5, endLine: 6, updatedAt: new Date().toISOString() };
+    await writeState();
+    await new Promise(resolve => setTimeout(resolve, 1800));
+    assert.equal(visible('reading.txt').selection.active.line, 1, 'Paused read moved cursor');
+    await vscode.commands.executeCommand('stvena.toggleFollow');
+    await waitFor(() => visible('reading.txt')?.selection.active.line === 4, 'Resume did not follow read');
+    delete value.activity;
+    await writeState();
+    await new Promise(resolve => setTimeout(resolve, 1800));
+    assert.equal(visible('reading.txt').selection.active.line, 4, 'Read expiry navigated to an old edit');
+    noDiffs();
+    console.log('STVENA_HOST_TESTS_PASSED: edits, reads, ranges, pause/resume, expiry, unsaved buffer, no diffs');
+  } finally {
+    await fs.rm(repo.statePath, { force: true });
+  }
+}
+
+module.exports = { run };

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -20,6 +20,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/vt"
 	"github.com/nccapo/stvena/internal/diffview"
+	"github.com/nccapo/stvena/internal/editor"
 	"github.com/nccapo/stvena/internal/review"
 	"github.com/nccapo/stvena/internal/ui"
 	"golang.org/x/term"
@@ -61,6 +62,11 @@ type contentEvent struct {
 
 // Run starts the requested agent command. With no arguments it runs Codex.
 func Run(args []string) error {
+	if len(args) == 1 && args[0] == "editor-hook" {
+		// Observers must never block an agent operation on a display failure.
+		_ = editor.RecordHook(os.Stdin)
+		return nil
+	}
 	if len(args) == 1 && args[0] == "--version" {
 		fmt.Fprintln(os.Stdout, "stvena "+Version)
 		return nil
@@ -147,7 +153,15 @@ func Run(args []string) error {
 	if !standalone {
 		state.launchCommand = append([]string(nil), args...)
 		state.startAgent = func(args []string, layout ui.Layout) (*agentTerminal, error) {
-			return startAgentTerminal(args, cwd, layout, events, stop)
+			var env []string
+			if savedSession != nil {
+				if executable, err := os.Executable(); err == nil {
+					env = []string{"STVENA_ACTIVITY_PATH=" + editor.ActivityPath(savedSession), "STVENA_ROOT=" + root,
+						"STVENA_SESSION=" + savedSession.ID, "STVENA_AGENT=" + filepath.Base(args[0])}
+					args = editor.HookArgs(args, executable)
+				}
+			}
+			return startAgentTerminal(args, cwd, layout, events, stop, env...)
 		}
 		a, err := state.startAgent(args, layout)
 		if err != nil {

--- a/internal/app/live_changes_test.go
+++ b/internal/app/live_changes_test.go
@@ -1,12 +1,16 @@
 package app
 
 import (
+	"encoding/json"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/nccapo/stvena/internal/diffview"
+	"github.com/nccapo/stvena/internal/editor"
 	"github.com/nccapo/stvena/internal/session"
 )
 
@@ -70,6 +74,26 @@ func TestChangesRefreshFromExternalProcess(t *testing.T) {
 		})
 		if e.project.Tree != e.session.Tree || e.snapshot.Tree != e.session.Tree {
 			t.Fatal("views did not refresh to the same captured files")
+		}
+		data, err := os.ReadFile(filepath.Join(root, ".git", "stvena-live.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var live editor.State
+		if err := json.Unmarshal(data, &live); err != nil {
+			t.Fatal(err)
+		}
+		if !live.Active || live.Session != saved.ID || live.Sequence == 0 || live.Error != "" {
+			t.Fatalf("watcher did not publish editor state: %+v", live)
+		}
+		found := false
+		for _, change := range live.Files {
+			if change.Path == "a.go" && change.Line == 2 {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("editor bridge missed edited line: %+v", live.Files)
 		}
 	}
 }

--- a/internal/app/terminal_scroll_test.go
+++ b/internal/app/terminal_scroll_test.go
@@ -1,0 +1,128 @@
+package app
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestAgentTerminalResizeDuringScrollSequence(t *testing.T) {
+	// An IDE panel change can shrink a 21-row terminal to 15 rows while a
+	// margin-setting escape sequence is only partly received from the PTY.
+	sequence := "\x1b[1;21r\x1b[H\x1bM"
+	for split := 0; split <= len(sequence); split++ {
+		t.Run(fmt.Sprint(split), func(t *testing.T) {
+			a := newAgentTerminal("test", 80, 21)
+			t.Cleanup(func() { _ = a.virtual.Close() })
+			_, _ = a.virtual.Write([]byte(sequence[:split]))
+			a.virtual.Resize(50, 15)
+			_, _ = a.virtual.Write([]byte(sequence[split:] + "\x1b[Halive"))
+			for x, want := range "alive" {
+				if cell := a.virtual.CellAt(x, 0); cell == nil || cell.Content != string(want) {
+					t.Fatalf("cell %d = %v, want %q", x, cell, want)
+				}
+			}
+		})
+	}
+}
+
+func TestAgentTerminalScrollAfterResize(t *testing.T) {
+	for _, alternate := range []bool{false, true} {
+		for _, horizontal := range []bool{false, true} {
+			for _, operation := range []string{"\x1bM", "\x1b[L", "\x1b[M", "\x1b[S", "\x1b[T"} {
+				t.Run(fmt.Sprintf("alternate=%t/horizontal=%t/operation=%q", alternate, horizontal, operation), func(t *testing.T) {
+					a := newAgentTerminal("test", 80, 40)
+					t.Cleanup(func() { _ = a.virtual.Close() })
+					write := func(data string) {
+						t.Helper()
+						if _, err := a.virtual.Write([]byte(data)); err != nil {
+							t.Fatal(err)
+						}
+					}
+					if alternate {
+						write("\x1b[?1049h")
+					}
+					if horizontal {
+						write("\x1b[?69h")
+					}
+					a.virtual.Resize(50, 26)
+					// Output queued before the resize still uses the old dimensions.
+					margins := "\x1b[1;40r"
+					if horizontal {
+						margins = "\x1b[1;80s"
+					}
+					// PTY reads can split an escape sequence at any byte.
+					for i := range margins {
+						write(margins[i : i+1])
+					}
+					write("\x1b[H" + operation + "alive")
+					for x, want := range "alive" {
+						cell := a.virtual.CellAt(x, 0)
+						if cell == nil || cell.Content != string(want) {
+							t.Fatalf("cell %d = %v, want %q", x, cell, want)
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestAgentTerminalScrollMarginsPreserveContent(t *testing.T) {
+	for _, tc := range []struct {
+		name, sequence string
+		want           [5]string
+	}{
+		{
+			name:     "stale bottom is clamped",
+			sequence: "\x1b[2;99r\x1b[2;1H\x1bM",
+			want:     [5]string{"AAAAAAAA", "        ", "BBBBBBBB", "CCCCCCCC", "DDDDDDDD"},
+		},
+		{
+			name:     "stale right is clamped",
+			sequence: "\x1b[?69h\x1b[3;99s\x1b[1;3H\x1bM",
+			want:     [5]string{"AA      ", "BBAAAAAA", "CCBBBBBB", "DDCCCCCC", "EEDDDDDD"},
+		},
+		{
+			name:     "valid margins retain outside rows",
+			sequence: "\x1b[2;4r\x1b[2;1H\x1bM",
+			want:     [5]string{"AAAAAAAA", "        ", "BBBBBBBB", "CCCCCCCC", "EEEEEEEE"},
+		},
+		{
+			name:     "missing defaults reset margins",
+			sequence: "\x1b[2;4r\x1b[r\x1b[H\x1bM",
+			want:     [5]string{"        ", "AAAAAAAA", "BBBBBBBB", "CCCCCCCC", "DDDDDDDD"},
+		},
+		{
+			name:     "zero defaults reset margins",
+			sequence: "\x1b[?69h\x1b[3;6s\x1b[0;0s\x1b[2;4r\x1b[0;0r\x1b[H\x1bM",
+			want:     [5]string{"        ", "AAAAAAAA", "BBBBBBBB", "CCCCCCCC", "DDDDDDDD"},
+		},
+		{
+			name:     "out of bounds start leaves previous margins",
+			sequence: "\x1b[2;4r\x1b[50;99r\x1b[2;1H\x1bM",
+			want:     [5]string{"AAAAAAAA", "        ", "BBBBBBBB", "CCCCCCCC", "EEEEEEEE"},
+		},
+		{
+			name:     "cursor save still works with margin mode off",
+			sequence: "\x1b[3;4H\x1b[s\x1b[H\x1b8X",
+			want:     [5]string{"AAAAAAAA", "BBBBBBBB", "CCCXCCCC", "DDDDDDDD", "EEEEEEEE"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := newAgentTerminal("test", 8, 5)
+			t.Cleanup(func() { _ = a.virtual.Close() })
+			for y, row := range []string{"AAAAAAAA", "BBBBBBBB", "CCCCCCCC", "DDDDDDDD", "EEEEEEEE"} {
+				_, _ = a.virtual.Write([]byte(fmt.Sprintf("\x1b[%d;1H%s", y+1, row)))
+			}
+			_, _ = a.virtual.Write([]byte(tc.sequence))
+			for y, row := range tc.want {
+				for x, want := range row {
+					cell := a.virtual.CellAt(x, y)
+					if cell == nil || cell.Content != string(want) {
+						t.Fatalf("cell (%d,%d) = %v, want %q", x, y, cell, want)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/app/terminals.go
+++ b/internal/app/terminals.go
@@ -29,6 +29,17 @@ type agentTerminal struct {
 
 func newAgentTerminal(name string, width, height int) *agentTerminal {
 	a := &agentTerminal{name: name, virtual: vt.NewEmulator(width, height), cursorVisible: true, status: "Running"}
+	// PTY output queued during resize can still specify the old scroll margins.
+	// Clamp before vt's default handlers store them and scroll outside the buffer.
+	// Remove when our vt version includes https://github.com/charmbracelet/x/pull/908.
+	a.virtual.RegisterCsiHandler('r', func(params ansi.Params) bool {
+		clampScrollMargin(params, a.virtual.Height())
+		return false // Let vt apply the margins and update the cursor normally.
+	})
+	a.virtual.RegisterCsiHandler('s', func(params ansi.Params) bool {
+		clampScrollMargin(params, a.virtual.Width())
+		return false // Also preserves CSI s cursor saving when margin mode is off.
+	})
 	a.virtual.SetCallbacks(vt.Callbacks{
 		CursorVisibility: func(visible bool) { a.cursorVisible = visible },
 		EnableMode: func(mode ansi.Mode) {
@@ -45,10 +56,18 @@ func newAgentTerminal(name string, width, height int) *agentTerminal {
 	return a
 }
 
-func startAgentTerminal(args []string, cwd string, layout ui.Layout, events chan<- any, stop <-chan struct{}) (*agentTerminal, error) {
+func clampScrollMargin(params ansi.Params, limit int) {
+	// Params shares the parser's storage, including the bottom margin that vt
+	// reads directly from its parser. Leave missing/zero defaults untouched.
+	if value, more, ok := params.Param(1, limit); ok && value > limit {
+		params[1] = ansi.Param(ansi.Parameter(limit, more))
+	}
+}
+
+func startAgentTerminal(args []string, cwd string, layout ui.Layout, events chan<- any, stop <-chan struct{}, extraEnv ...string) (*agentTerminal, error) {
 	command := exec.Command(args[0], args[1:]...)
 	command.Dir = cwd
-	command.Env = withTerminalEnv(os.Environ())
+	command.Env = append(withTerminalEnv(os.Environ()), extraEnv...)
 	ptmx, err := pty.StartWithSize(command, &pty.Winsize{Cols: uint16(layout.LeftWidth), Rows: uint16(layout.LeftHeight)})
 	if err != nil {
 		return nil, fmt.Errorf("start %s: %w", args[0], err)

--- a/internal/app/workspace.go
+++ b/internal/app/workspace.go
@@ -14,6 +14,7 @@ import (
 	"github.com/creack/pty"
 	"github.com/nccapo/stvena/internal/checks"
 	"github.com/nccapo/stvena/internal/diffview"
+	"github.com/nccapo/stvena/internal/editor"
 	"github.com/nccapo/stvena/internal/session"
 	"github.com/nccapo/stvena/internal/ui"
 )
@@ -23,6 +24,11 @@ func watchSnapshots(root string, rootErr error, saved *session.Session, events c
 		watchDiff(root, rootErr, events, stop)
 		return
 	}
+	publisher, bridgeErr := editor.Open(saved)
+	if bridgeErr == nil {
+		defer publisher.Close()
+	}
+	bridgeReported := false
 	var project diffview.Snapshot
 	refresh := func() {
 		tree, err := saved.Capture()
@@ -48,6 +54,17 @@ func watchSnapshots(root string, rootErr error, saved *session.Session, events c
 		if err != nil {
 			deliveredProject.Err = fmt.Errorf("Project capture failed: %w", err)
 		}
+		if publisher != nil {
+			bridgeErr = publisher.Publish(tree, err)
+		}
+		if bridgeErr != nil && !bridgeReported {
+			select {
+			case events <- operationEvent{message: "Editor live view unavailable", err: bridgeErr}:
+			case <-stop:
+				return
+			}
+		}
+		bridgeReported = bridgeErr != nil
 		select {
 		case events <- diffEvent{snapshot: workspace, session: view, project: deliveredProject}:
 		case <-stop:

--- a/internal/editor/activity.go
+++ b/internal/editor/activity.go
@@ -1,0 +1,265 @@
+package editor
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nccapo/stvena/internal/session"
+)
+
+type LineRange struct {
+	Start int `json:"start"`
+	End   int `json:"end"`
+}
+
+type Activity struct {
+	Session   string    `json:"session"`
+	ID        string    `json:"id"`
+	Agent     string    `json:"agent"`
+	Path      string    `json:"path"`
+	Line      int       `json:"line"`
+	EndLine   int       `json:"endLine,omitempty"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+func ActivityPath(saved *session.Session) string {
+	return filepath.Join(saved.Dir, saved.ID+"-activity.json")
+}
+
+// HookArgs adds invocation-local observers, leaving persistent agent settings alone.
+// Codex still applies its normal hook trust review. Explicit Claude settings are
+// left intact; users can add the documented hook to those settings themselves.
+func HookArgs(args []string, executable string) []string {
+	if len(args) == 0 {
+		return args
+	}
+	name := filepath.Base(args[0])
+	command := "'" + strings.ReplaceAll(executable, "'", "'\"'\"'") + "' editor-hook"
+	extra := []string{}
+	switch name {
+	case "codex":
+		extra = []string{"-c", "hooks.PostToolUse=[{matcher=\"Bash|Read\",hooks=[{type=\"command\",command=" + strconv.Quote(command) + ",timeout=2}]}]"}
+	case "claude":
+		for _, arg := range args[1:] {
+			if arg == "--settings" || strings.HasPrefix(arg, "--settings=") {
+				return args
+			}
+		}
+		config := map[string]any{"hooks": map[string]any{"PostToolUse": []any{map[string]any{"matcher": "Read|Bash", "hooks": []any{map[string]any{"type": "command", "command": command, "timeout": 2}}}}}}
+		data, _ := json.Marshal(config)
+		extra = []string{"--settings", string(data)}
+	default:
+		return args
+	}
+	return append(append([]string{args[0]}, extra...), args[1:]...)
+}
+
+// RecordHook is an observational hook: it never returns an approval decision,
+// emits context to the agent, or executes any of the reported command text.
+func RecordHook(input io.Reader) error {
+	target, root, sessionID := os.Getenv("STVENA_ACTIVITY_PATH"), os.Getenv("STVENA_ROOT"), os.Getenv("STVENA_SESSION")
+	if target == "" || root == "" || sessionID == "" {
+		return nil
+	}
+	var event struct {
+		Event string `json:"hook_event_name"`
+		CWD   string `json:"cwd"`
+		Tool  string `json:"tool_name"`
+		ID    string `json:"tool_use_id"`
+		Input struct {
+			File    string `json:"file_path"`
+			Path    string `json:"path"`
+			Offset  int    `json:"offset"`
+			Limit   int    `json:"limit"`
+			Command string `json:"command"`
+			Cmd     string `json:"cmd"`
+			Workdir string `json:"workdir"`
+		} `json:"tool_input"`
+	}
+	if err := json.NewDecoder(io.LimitReader(input, 1024*1024)).Decode(&event); err != nil {
+		return err
+	}
+	if event.Event != "PostToolUse" {
+		return nil
+	}
+	file, line, end := "", 1, 0
+	switch event.Tool {
+	case "Read":
+		if event.Input.Offset < 0 || event.Input.Offset > 1000000 || event.Input.Limit < 0 || event.Input.Limit > 1000000 {
+			return nil
+		}
+		file = event.Input.File
+		if file == "" {
+			file = event.Input.Path
+		}
+		line = max(1, event.Input.Offset)
+		if event.Input.Limit > 0 && event.Input.Limit <= 1000000 && line <= 1000000 {
+			end = line + event.Input.Limit - 1
+		}
+	case "Bash", "exec_command", "shell_command":
+		command := event.Input.Command
+		if command == "" {
+			command = event.Input.Cmd
+		}
+		file, line, end = readCommand(command)
+	default:
+		return nil
+	}
+	if file == "" {
+		return nil
+	}
+	cwd := event.CWD
+	if cwd == "" {
+		cwd = root
+	}
+	if event.Input.Workdir != "" {
+		if filepath.IsAbs(event.Input.Workdir) {
+			cwd = event.Input.Workdir
+		} else {
+			cwd = filepath.Join(cwd, event.Input.Workdir)
+		}
+	}
+	if !filepath.IsAbs(file) {
+		file = filepath.Join(cwd, file)
+	}
+	// Resolve symlinks too: never advertise a file outside the workspace.
+	realRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return err
+	}
+	file, err = filepath.EvalSymlinks(file)
+	if err != nil {
+		return nil
+	}
+	relative, err := filepath.Rel(realRoot, file)
+	if err != nil || relative == "." || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return nil
+	}
+	info, err := os.Stat(file)
+	if err != nil || !info.Mode().IsRegular() {
+		return nil
+	}
+	now := time.Now().UTC()
+	return session.AtomicJSON(target, Activity{Session: sessionID, ID: fmt.Sprintf("%s:%d", event.ID, now.UnixNano()),
+		Agent: os.Getenv("STVENA_AGENT"), Path: filepath.ToSlash(relative), Line: line, EndLine: end, UpdatedAt: now})
+}
+
+// Recognize only unambiguous single-file read commands. Complex shell programs
+// and searches do not provide a reliable source range and are deliberately skipped.
+func readCommand(command string) (string, int, int) {
+	args, ok := readWords(strings.TrimSpace(command))
+	if !ok || len(args) < 2 {
+		return "", 0, 0
+	}
+	switch args[0] {
+	case "cat":
+		if len(args) == 2 && !strings.HasPrefix(args[1], "-") {
+			return args[1], 1, 0
+		}
+	case "head":
+		if len(args) == 4 && args[1] == "-n" && !strings.HasPrefix(args[3], "-") {
+			n, err := strconv.Atoi(args[2])
+			if err == nil && n > 0 && n <= 1000000 {
+				return args[3], 1, n
+			}
+		}
+	case "sed":
+		if len(args) == 4 && args[1] == "-n" && strings.HasSuffix(args[2], "p") && !strings.HasPrefix(args[3], "-") {
+			bounds := strings.Split(strings.TrimSuffix(args[2], "p"), ",")
+			if len(bounds) == 1 {
+				bounds = append(bounds, bounds[0])
+			}
+			if len(bounds) == 2 {
+				a, e1 := strconv.Atoi(bounds[0])
+				b, e2 := strconv.Atoi(bounds[1])
+				if e1 == nil && e2 == nil && a > 0 && b >= a && b <= 1000000 {
+					return args[3], a, b
+				}
+			}
+		}
+	}
+	return "", 0, 0
+}
+
+func readWords(command string) ([]string, bool) {
+	var words []string
+	var word strings.Builder
+	var quote rune
+	started := false
+	for _, c := range command {
+		if quote != 0 {
+			if c == quote {
+				quote = 0
+			} else {
+				if quote == '"' && strings.ContainsRune("$`\\", c) {
+					return nil, false
+				}
+				word.WriteRune(c)
+			}
+		} else {
+			switch c {
+			case '\'', '"':
+				quote = c
+				started = true
+			case ' ', '\t':
+				if started {
+					words = append(words, word.String())
+					word.Reset()
+					started = false
+				}
+			default:
+				if strings.ContainsRune("\n\r;&|<>$`\\()*?{}[]~", c) {
+					return nil, false
+				}
+				word.WriteRune(c)
+				started = true
+			}
+		}
+	}
+	if quote != 0 {
+		return nil, false
+	}
+	if started {
+		words = append(words, word.String())
+	}
+	return words, true
+}
+
+func changedRanges(lines []string) []LineRange {
+	var ranges []LineRange
+	line, inHunk := 1, false
+	for _, text := range lines {
+		if strings.HasPrefix(text, "@@ ") {
+			fields := strings.Fields(text)
+			if len(fields) >= 3 {
+				_, _ = fmt.Sscanf(strings.Split(fields[2], ",")[0], "+%d", &line)
+				inHunk = true
+			}
+			continue
+		}
+		if !inHunk || text == "" {
+			continue
+		}
+		switch text[0] {
+		case '+', '-':
+			current := max(1, line)
+			if len(ranges) > 0 && current <= ranges[len(ranges)-1].End+1 {
+				ranges[len(ranges)-1].End = max(current, ranges[len(ranges)-1].End)
+			} else {
+				ranges = append(ranges, LineRange{current, current})
+			}
+			if text[0] == '+' {
+				line++
+			}
+		case ' ':
+			line++
+		}
+	}
+	return ranges
+}

--- a/internal/editor/activity_test.go
+++ b/internal/editor/activity_test.go
@@ -1,0 +1,117 @@
+package editor
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestReadCommand(t *testing.T) {
+	for _, tc := range []struct {
+		command, path string
+		start, end    int
+	}{
+		{"sed -n '40,65p' 'space name.go'", "space name.go", 40, 65},
+		{"sed -n \"9p\" a.go", "a.go", 9, 9},
+		{"head -n 25 a.go", "a.go", 1, 25},
+		{"cat a.go", "a.go", 1, 0},
+		{"cat a.go b.go", "", 0, 0},
+		{"cat $(echo a.go)", "", 0, 0},
+		{"cat a.go && rm a.go", "", 0, 0},
+		{"sed -n '8,2p' a.go", "", 0, 0},
+		{"sed -n '1,5p' a.go > out", "", 0, 0},
+		{"head -n -5 a.go", "", 0, 0},
+		{"cat \"$FILE\"", "", 0, 0},
+		{"rg -n pattern a.go", "", 0, 0},
+	} {
+		p, a, b := readCommand(tc.command)
+		if p != tc.path || a != tc.start || b != tc.end {
+			t.Errorf("%s: got %q %d %d", tc.command, p, a, b)
+		}
+	}
+}
+
+func TestRecordHook(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(t.TempDir(), "activity.json")
+	t.Setenv("STVENA_ACTIVITY_PATH", target)
+	t.Setenv("STVENA_ROOT", root)
+	t.Setenv("STVENA_SESSION", "test-session")
+	t.Setenv("STVENA_AGENT", "claude")
+	if err := os.WriteFile(filepath.Join(root, "a.go"), []byte("one\ntwo\nthree\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	record := func(tool string, input map[string]any) {
+		t.Helper()
+		data, _ := json.Marshal(map[string]any{"hook_event_name": "PostToolUse", "cwd": root, "tool_name": tool, "tool_use_id": "call-1", "tool_input": input})
+		if err := RecordHook(strings.NewReader(string(data))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	record("Read", map[string]any{"file_path": "a.go", "offset": 2, "limit": 2})
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got Activity
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Path != "a.go" || got.Line != 2 || got.EndLine != 3 || got.Session != "test-session" || got.Agent != "claude" {
+		t.Fatalf("%+v", got)
+	}
+	outside := filepath.Join(t.TempDir(), "outside.go")
+	if err := os.WriteFile(outside, []byte("outside"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "link.go")); err != nil {
+		t.Fatal(err)
+	}
+	record("Read", map[string]any{"file_path": "link.go"})
+	record("Read", map[string]any{"file_path": outside})
+	record("Bash", map[string]any{"command": "rm a.go"})
+	current, _ := os.ReadFile(target)
+	if string(current) != string(data) {
+		t.Fatal("unsupported or outside read replaced activity")
+	}
+	record("Bash", map[string]any{"command": "sed -n '1,2p' a.go"})
+	current, _ = os.ReadFile(target)
+	if err := json.Unmarshal(current, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Line != 1 || got.EndLine != 2 {
+		t.Fatalf("%+v", got)
+	}
+}
+
+func TestHookArgs(t *testing.T) {
+	args := []string{"codex", "resume", "--last"}
+	got := HookArgs(args, "/tmp/agent's dir/stvena")
+	if got[1] != "-c" || !strings.Contains(got[2], "hooks.PostToolUse") || !reflect.DeepEqual(got[3:], args[1:]) {
+		t.Fatal(got)
+	}
+	claude := HookArgs([]string{"claude", "--resume"}, "/tmp/stvena")
+	var config map[string]any
+	if claude[1] != "--settings" || json.Unmarshal([]byte(claude[2]), &config) != nil {
+		t.Fatal(claude)
+	}
+	explicit := []string{"claude", "--settings", "custom.json"}
+	if !reflect.DeepEqual(HookArgs(explicit, "/tmp/stvena"), explicit) {
+		t.Fatal("overrode explicit settings")
+	}
+	custom := []string{"custom", "arg"}
+	if !reflect.DeepEqual(HookArgs(custom, "/tmp/stvena"), custom) {
+		t.Fatal("modified custom command")
+	}
+}
+
+func TestChangedRanges(t *testing.T) {
+	patch := []string{"@@ -1,4 +1,5 @@", " context", "-old", "+new", "+second", " context", "@@ -40,3 +41,2 @@", " context", "-deleted", " context"}
+	want := []LineRange{{2, 3}, {42, 42}}
+	if got := changedRanges(patch); !reflect.DeepEqual(got, want) {
+		t.Fatalf("%+v != %+v", got, want)
+	}
+}

--- a/internal/editor/bridge.go
+++ b/internal/editor/bridge.go
@@ -1,0 +1,145 @@
+// Package editor publishes captured edits for local editor integrations.
+package editor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/nccapo/stvena/internal/diffview"
+	"github.com/nccapo/stvena/internal/session"
+)
+
+// State is protocol v1. Files describes the most recent capture that changed,
+// not the cumulative session diff. Heartbeats keep idle sessions discoverable.
+type State struct {
+	Version   int       `json:"version"`
+	Session   string    `json:"session"`
+	Sequence  uint64    `json:"sequence"`
+	Active    bool      `json:"active"`
+	UpdatedAt time.Time `json:"updatedAt"`
+	Error     string    `json:"error,omitempty"`
+	Files     []Change  `json:"files"`
+	Activity  *Activity `json:"activity,omitempty"`
+	ChangedAt time.Time `json:"changedAt,omitempty"`
+}
+
+type Change struct {
+	Path      string      `json:"path"`
+	OldPath   string      `json:"oldPath,omitempty"`
+	Status    string      `json:"status"`
+	Before    string      `json:"before"`
+	After     string      `json:"after"`
+	Line      int         `json:"line"`
+	Added     int         `json:"added"`
+	Deleted   int         `json:"deleted"`
+	Binary    bool        `json:"binary"`
+	Truncated bool        `json:"truncated"`
+	Ranges    []LineRange `json:"ranges,omitempty"`
+}
+
+type Publisher struct {
+	path, root, previous string
+	state                State
+	activityPath         string
+}
+
+func Open(saved *session.Session) (*Publisher, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "git", "-C", saved.Root, "rev-parse", "--absolute-git-dir").Output()
+	if err != nil {
+		return nil, err
+	}
+	return &Publisher{
+		path: filepath.Join(strings.TrimSuffix(string(out), "\n"), "stvena-live.json"),
+		root: saved.Root, previous: saved.Baseline,
+		activityPath: ActivityPath(saved),
+		state:        State{Version: 1, Session: saved.ID, Active: true, Files: []Change{}},
+	}, nil
+}
+
+func (p *Publisher) Publish(tree string, captureErr error) error {
+	next := p.state
+	previous := p.previous
+	next.Error = ""
+	if captureErr == nil && tree != p.previous {
+		delta := diffview.CompareTrees(p.root, p.previous, tree)
+		captureErr = delta.Err
+		if captureErr == nil {
+			files := make([]Change, 0, len(delta.Files))
+			for _, f := range delta.Files {
+				files = append(files, Change{
+					Path: f.Path, OldPath: f.OldPath, Status: f.Status,
+					Before: f.BeforeOID, After: f.AfterOID, Line: changedLine(f.Lines),
+					Added: f.Added, Deleted: f.Deleted, Binary: f.Binary, Truncated: f.Truncated,
+					Ranges: changedRanges(f.Lines),
+				})
+			}
+			next.Files = files
+			next.Sequence++
+			next.ChangedAt = time.Now().UTC()
+			previous = tree
+		}
+	}
+	if captureErr != nil {
+		next.Error = captureErr.Error()
+	}
+	next.UpdatedAt = time.Now().UTC()
+	next.Activity = nil
+	if data, err := os.ReadFile(p.activityPath); err == nil && len(data) <= 64*1024 {
+		var activity Activity
+		if json.Unmarshal(data, &activity) == nil && activity.Session == next.Session &&
+			time.Since(activity.UpdatedAt) < 15*time.Second && time.Since(activity.UpdatedAt) >= 0 {
+			next.Activity = &activity
+		}
+	}
+	if err := session.AtomicJSON(p.path, next); err != nil {
+		return err
+	}
+	p.state, p.previous = next, previous
+	return nil
+}
+
+func (p *Publisher) Close() {
+	// Do not overwrite another process's descriptor after it has taken over.
+	data, err := os.ReadFile(p.path)
+	var current State
+	if err != nil || json.Unmarshal(data, &current) != nil || current.Session != p.state.Session {
+		return
+	}
+	p.state.Active = false
+	p.state.UpdatedAt = time.Now().UTC()
+	_ = session.AtomicJSON(p.path, p.state)
+}
+
+// Report the first changed line in the new file, skipping hunk context. A
+// deletion points at its surviving neighbor, clamped by the editor at EOF.
+func changedLine(lines []string) int {
+	line, inHunk := 1, false
+	for _, text := range lines {
+		if strings.HasPrefix(text, "@@ ") {
+			fields := strings.Fields(text)
+			if len(fields) >= 3 {
+				_, _ = fmt.Sscanf(strings.Split(fields[2], ",")[0], "+%d", &line)
+				inHunk = true
+			}
+			continue
+		}
+		if !inHunk || text == "" {
+			continue
+		}
+		switch text[0] {
+		case '+', '-':
+			return max(1, line)
+		case ' ':
+			line++
+		}
+	}
+	return 1
+}

--- a/internal/editor/bridge_test.go
+++ b/internal/editor/bridge_test.go
@@ -1,0 +1,169 @@
+package editor
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nccapo/stvena/internal/session"
+)
+
+func TestPublishCapturedEdits(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	root := t.TempDir()
+	git := func(args ...string) string {
+		t.Helper()
+		out, err := exec.Command("git", append([]string{"-C", root}, args...)...).CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %s: %v", args, out, err)
+		}
+		return string(out)
+	}
+	git("init", "-q")
+	write := func(name, value string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(root, name), []byte(value), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("a.txt", "one\ntwo\nthree\nfour\nold\n")
+	write("delete.txt", "delete me\n")
+	write("rename.txt", "rename me\n")
+	saved, err := session.Open(root, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer saved.Close()
+	publisher, err := Open(saved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	read := func() State {
+		t.Helper()
+		data, err := os.ReadFile(publisher.path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var state State
+		if err := json.Unmarshal(data, &state); err != nil {
+			t.Fatal(err)
+		}
+		return state
+	}
+	publish := func() State {
+		t.Helper()
+		tree, err := saved.Capture()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := publisher.Publish(tree, nil); err != nil {
+			t.Fatal(err)
+		}
+		return read()
+	}
+	initial := publish()
+	if initial.Sequence != 0 || len(initial.Files) != 0 || !initial.Active || initial.Version != 1 {
+		t.Fatalf("initial state: %+v", initial)
+	}
+	activity := Activity{Session: saved.ID, ID: "read-1", Agent: "codex", Path: "a.txt", Line: 2, EndLine: 4, UpdatedAt: time.Now().UTC()}
+	if err := session.AtomicJSON(ActivityPath(saved), activity); err != nil {
+		t.Fatal(err)
+	}
+	if reading := publish(); reading.Sequence != 0 || reading.Activity == nil || reading.Activity.ID != "read-1" {
+		t.Fatalf("read-only activity was not published: %+v", reading)
+	}
+	activity.UpdatedAt = time.Now().Add(-16 * time.Second)
+	if err := session.AtomicJSON(ActivityPath(saved), activity); err != nil {
+		t.Fatal(err)
+	}
+	if publish().Activity != nil {
+		t.Fatal("expired activity still advertised")
+	}
+	activity.UpdatedAt, activity.Session = time.Now(), "another-session"
+	if err := session.AtomicJSON(ActivityPath(saved), activity); err != nil {
+		t.Fatal(err)
+	}
+	if publish().Activity != nil {
+		t.Fatal("activity from another session advertised")
+	}
+	write("a.txt", "one\ntwo\nthree\nfour\nnew\n")
+	write("added.txt", "added\n")
+	write("binary.dat", "\x00\x01")
+	if err := os.Remove(filepath.Join(root, "delete.txt")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(filepath.Join(root, "rename.txt"), filepath.Join(root, "renamed.txt")); err != nil {
+		t.Fatal(err)
+	}
+	first := publish()
+	files := map[string]Change{}
+	for _, file := range first.Files {
+		files[file.Path] = file
+	}
+	if first.Sequence != 1 || len(files) != 5 || files["a.txt"].Line != 5 ||
+		files["added.txt"].Status != "A" || files["delete.txt"].Status != "D" ||
+		files["renamed.txt"].OldPath != "rename.txt" || !files["binary.dat"].Binary {
+		t.Fatalf("captured batch: %+v", first)
+	}
+	if first.ChangedAt.IsZero() || len(files["a.txt"].Ranges) != 1 || files["a.txt"].Ranges[0] != (LineRange{5, 5}) {
+		t.Fatalf("missing edit range or timestamp: %+v", first)
+	}
+	if got := git("cat-file", "blob", files["a.txt"].Before); got != "one\ntwo\nthree\nfour\nold\n" {
+		t.Fatalf("wrong before content: %q", got)
+	}
+	if idle := publish(); idle.Sequence != first.Sequence || !idle.UpdatedAt.After(first.UpdatedAt) {
+		t.Fatalf("heartbeat lost last edit: %+v", idle)
+	}
+	write("a.txt", "one\ntwo\nthree\nfour\nnewer\n")
+	// A failed descriptor replacement must not advance past an unseen capture.
+	tree, err := saved.Capture()
+	if err != nil {
+		t.Fatal(err)
+	}
+	statePath := publisher.path
+	publisher.path = filepath.Join(root, "missing-directory", "state.json")
+	if err := publisher.Publish(tree, nil); err == nil {
+		t.Fatal("expected descriptor write failure")
+	}
+	if publisher.state.Sequence != first.Sequence {
+		t.Fatal("failed write advanced the published sequence")
+	}
+	publisher.path = statePath
+	second := publish()
+	if second.Sequence != 2 || len(second.Files) != 1 || second.Files[0].Before != files["a.txt"].After {
+		t.Fatalf("must compare consecutive captures: %+v", second)
+	}
+	if err := publisher.Publish("", errors.New("capture failed")); err != nil {
+		t.Fatal(err)
+	}
+	if failed := read(); failed.Error != "capture failed" || failed.Sequence != 2 {
+		t.Fatalf("capture failure lost previous state: %+v", failed)
+	}
+	if recovered := publish(); recovered.Error != "" || recovered.Sequence != 2 {
+		t.Fatalf("capture did not recover: %+v", recovered)
+	}
+	publisher.Close()
+	if read().Active {
+		t.Fatal("session still advertised as active after shutdown")
+	}
+}
+
+func TestChangedLine(t *testing.T) {
+	for _, test := range []struct {
+		lines []string
+		want  int
+	}{
+		{[]string{"--- a/file", "+++ b/file", "@@ -8,3 +8,3 @@", " context", "-old", "+new"}, 9},
+		{[]string{"@@ -1 +0,0 @@", "-deleted"}, 1},
+		{[]string{"@@ -0,0 +1 @@", "+new"}, 1},
+		{[]string{"No text patch available"}, 1},
+	} {
+		if got := changedLine(test.lines); got != test.want {
+			t.Errorf("changedLine(%q) = %d, want %d", test.lines, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
Includes:  
 
  - macOS and Linux binaries for Intel/AMD and ARM. 
  - Stvena Live VSIX for VS Code and Antigravity.
  - Checksums and installation instructions. 
   
CI passed, all download checksums verified, and the installer and extension installations succeeded. The stable release remains v0.1.4.