### PR TITLE
Add live agent attention states and Homebrew installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,44 @@ You need **Git**, an interactive terminal, and your chosen agent CLI installed
 and authenticated. Stvena uses Unix PTYs and process groups; macOS and Linux are
 the intended platforms. Native Windows is not supported.
 
-### Prebuilt binary (recommended)
+### Homebrew (macOS and Linux)
+
+With Homebrew installed, run:
+
+```sh
+brew install nccapo/stvena/stvena
+stvena --version
+```
+
+This taps [nccapo/homebrew-stvena](https://github.com/nccapo/homebrew-stvena),
+trusts only the `stvena` formula, and installs a prebuilt binary verified against
+the release's SHA-256 checksum. No Go installation is required. The formula
+supports Apple Silicon and Intel Macs, plus ARM64 and amd64 Linux systems.
+Install and authenticate Codex or Claude Code separately before launching Stvena.
+
+The tap tracks stable releases by default. To upgrade or uninstall:
+
+```sh
+brew upgrade stvena
+brew uninstall stvena
+```
+
+Preview releases are not installed automatically. For the editor integration
+preview, follow [Follow reads and edits in VS Code](#follow-reads-and-edits-in-vs-code).
+
+If you previously used `install.sh` and Homebrew reports an existing binary in
+`/opt/homebrew/bin` or `/usr/local/bin`, locate it first:
+
+```sh
+command -v stvena
+```
+
+Remove that manually installed Stvena binary if it occupies Homebrew's target
+path, then rerun `brew install nccapo/stvena/stvena`. See the
+[tap documentation](https://github.com/nccapo/homebrew-stvena#coming-from-installsh)
+for migration details.
+
+### Install script (macOS and Linux)
 
 No Go installation is required:
 
@@ -78,9 +115,6 @@ To choose the installation directory or install a specific release:
 curl -fsSL https://raw.githubusercontent.com/nccapo/stvena/main/install.sh | \
   STVENA_INSTALL_DIR="$HOME/.local/bin" STVENA_VERSION=v0.1.0 sh
 ```
-
-Homebrew is not required. A dedicated Homebrew tap is not published yet, so the
-verified installer is currently the shortest supported installation path.
 
 ### Install with Go or build from source
 
@@ -144,6 +178,7 @@ but direct selection paste is supported for Codex and Claude Code.
 | **Ctrl-G** | Switch between agent and review |
 | **Ctrl-]** | Open another agent terminal |
 | **Ctrl-N / Ctrl-P** | Next / previous agent terminal |
+| **Ctrl-Y** | Next attention: error, review, waiting, changed, running, done |
 | **Ctrl-W** | Close current agent terminal and stop its command |
 | **Ctrl-Q** | Quit Stvena and stop all agents |
 | **1 / 2 / 3** | Session changes / workspace changes / project files |
@@ -203,6 +238,60 @@ inspection. Closing the last agent leaves the review workspace open, where
 Agent terminals are live processes rather than saved conversations. Reopening a
 saved review does not restart them, and multiple-agent shortcuts are unavailable
 in standalone `stvena review` mode.
+
+## Agent attention
+
+A compact strip above the panes shows every terminal's stable name and status:
+`● RUNNING`, `! REVIEW`, `? WAITING`, `+ CHANGED`, `✓ DONE`, `× ERROR`, or
+`· IDLE`. Brackets identify the active terminal; `→` identifies the highest
+attention priority. Color reinforces these text labels. `3f` always means three
+unreviewed file paths (a rename can include both paths). `/ RUN` means the agent is still working while it needs review.
+The header counts agents, running agents, agents with unreviewed files, waiting
+agents, and errors. The strip uses at most two rows; overflow keeps the highest
+priority agent visible and shows how many other agents are hidden.
+
+**Ctrl-Y** (Next attention) starts at the highest priority and cycles through
+error → review → waiting → changed → running → done. Normal terminal navigation
+resets the cycle. Configure it in **? → Configuration**, like the other global
+shortcuts; the footer also provides Next attention. Command-Y is an optional
+alias when the terminal forwards it. No background event switches panes.
+
+Selecting attention opens the relevant file in **This session** when possible.
+An existing pinned checkpoint or unfinished review input stays intact. The
+normal **e** editor action then opens that file; the live editor bridge continues
+to publish combined workspace changes.
+
+**REVIEW clears only after Space marks the captured file reviewed, or H marks
+all its hunks reviewed, in This session or a session checkpoint.** Opening the
+agent or diff does not acknowledge it. Reviewing an older pinned version does
+not clear newer changes. An acknowledged session stays clear when another agent
+later edits the same path. New edits by the original agent create new review
+items. If edits are reverted before capture, Next attention offers an explicit
+no-net-change acknowledgement. Closing a terminal removes its live indicators;
+its changes and existing review records remain in the shared workspace.
+
+Execution, review, activity time and changed-file ownership are separate state.
+Attention priority is derived from them. Invocation-local observers use
+[Claude hooks](https://code.claude.com/docs/en/hooks) and
+[Codex hooks](https://developers.openai.com/codex/hooks): prompt/tool events mark
+running, Stop marks a completed turn, Claude StopFailure and unsuccessful process
+exits mark error. Claude permission/idle notifications provide waiting signals.
+Without structured hooks, PTY output means running; three seconds without output
+means idle, **never** waiting or completed. A successful process exit means done.
+
+File attribution compares named files before and after Claude Edit/Write/MultiEdit
+or Codex apply_patch calls, including additions, deletions and renames. The git
+snapshot watcher then supplies captured review versions. Arbitrary shell/MCP
+writes and commands without hooks cannot be reliably attributed in a shared
+working directory; they remain visible in the combined diff without assigning
+an owner. Concurrent edits to the same file are reviewed against its combined
+captured diff. Git-ignored files are outside the normal diff capture.
+
+Codex must support and trust the configured hooks. Explicit Claude `--settings`
+are preserved, so automatic observers are not added in that case. Codex waiting
+prompts and CLI turn failures without a supported event cannot be detected
+reliably; Stvena does not infer them from terminal text. Live attention state is
+not restored after restarting Stvena; saved review records continue to work.
 
 ## Follow reads and edits in VS Code
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,10 +1,12 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/nccapo/stvena/internal/attention"
 	"github.com/nccapo/stvena/internal/checks"
 	"github.com/nccapo/stvena/internal/session"
 	"io"
@@ -64,7 +66,9 @@ type contentEvent struct {
 func Run(args []string) error {
 	if len(args) == 1 && args[0] == "editor-hook" {
 		// Observers must never block an agent operation on a display failure.
-		_ = editor.RecordHook(os.Stdin)
+		data, _ := io.ReadAll(io.LimitReader(os.Stdin, 1024*1024))
+		_ = attention.RecordHook(bytes.NewReader(data))
+		_ = editor.RecordHook(bytes.NewReader(data))
 		return nil
 	}
 	if len(args) == 1 && args[0] == "--version" {
@@ -72,7 +76,7 @@ func Run(args []string) error {
 		return nil
 	}
 	if len(args) == 1 && (args[0] == "--help" || args[0] == "-h") {
-		fmt.Fprintln(os.Stdout, "Usage: stvena [--] [command [args...]]\n       stvena review [--session ID]\n       stvena sessions\n\nDefault command: codex. The bottom panel starts focused on Configuration.\nArrows select, Enter activates, Esc returns to the agent or review. F6 can refocus the panel.\nSelect Configuration to change global or review shortcuts for all projects.\nCtrl-G switches panes (agent/workspace), preserving the open file; a opens Actions.\nCtrl-] chooses Codex, Claude Code, or the launch command for a new terminal. Ctrl-N / Ctrl-P switch agent terminals.\nCtrl-W closes the current agent terminal and stops its command.\nCtrl-Q closes stvena and stops all running commands. Ctrl-C interrupts the command.\nReview stays open after commands exit. q closes review once all agents finish.\nRun inside the repository you want to review.")
+		fmt.Fprintln(os.Stdout, "Usage: stvena [--] [command [args...]]\n       stvena review [--session ID]\n       stvena sessions\n\nDefault command: codex. The bottom panel starts focused on Configuration.\nArrows select, Enter activates, Esc returns to the agent or review. F6 can refocus the panel.\nSelect Configuration to change global or review shortcuts for all projects.\nCtrl-G switches panes (agent/workspace), preserving the open file; a opens Actions.\nCtrl-] chooses Codex, Claude Code, or the launch command for a new terminal. Ctrl-N / Ctrl-P switch agent terminals.\nCtrl-Y selects the next agent needing attention.\nCtrl-W closes the current agent terminal and stops its command.\nCtrl-Q closes stvena and stops all running commands. Ctrl-C interrupts the command.\nReview stays open after commands exit. q closes review once all agents finish.\nRun inside the repository you want to review.")
 		return nil
 	}
 	if len(args) == 1 && args[0] == "sessions" {
@@ -153,15 +157,28 @@ func Run(args []string) error {
 	if !standalone {
 		state.launchCommand = append([]string(nil), args...)
 		state.startAgent = func(args []string, layout ui.Layout) (*agentTerminal, error) {
-			var env []string
-			if savedSession != nil {
-				if executable, err := os.Executable(); err == nil {
-					env = []string{"STVENA_ACTIVITY_PATH=" + editor.ActivityPath(savedSession), "STVENA_ROOT=" + root,
-						"STVENA_SESSION=" + savedSession.ID, "STVENA_AGENT=" + filepath.Base(args[0])}
-					args = editor.HookArgs(args, executable)
-				}
+			dir, err := os.MkdirTemp("", "stvena-attention-")
+			if err != nil {
+				return nil, err
 			}
-			return startAgentTerminal(args, cwd, layout, events, stop, env...)
+			env := []string{"STVENA_ROOT=" + root, "STVENA_ATTENTION_DIR=" + dir}
+			if savedSession != nil {
+				env = append(env, "STVENA_ACTIVITY_PATH="+editor.ActivityPath(savedSession), "STVENA_SESSION="+savedSession.ID, "STVENA_AGENT="+filepath.Base(args[0]))
+			}
+			if executable, err := os.Executable(); err == nil {
+				args = editor.HookArgs(args, executable)
+			}
+
+			a, err := startAgentTerminal(args, cwd, layout, events, stop, env...)
+			if err != nil {
+				_ = os.RemoveAll(dir)
+				return nil, err
+			}
+			done := make(chan struct{})
+			go func() { defer close(done); watchAttention(a, dir, events, stop) }()
+			closeTerminal := a.close
+			a.close = sync.OnceFunc(func() { closeTerminal(); close(a.attentionStop); <-done; _ = os.RemoveAll(dir) })
+			return a, nil
 		}
 		a, err := state.startAgent(args, layout)
 		if err != nil {
@@ -289,8 +306,12 @@ func Run(args []string) error {
 				if value.agent.closed {
 					continue
 				}
+				value.agent.attention.Output(time.Now())
 				_, _ = value.agent.virtual.Write(value.data)
 				state.syncAgent()
+				dirty = true
+			case attentionEvent:
+				state.applyAttention(value)
 				dirty = true
 			case diffEvent:
 				state.workspace = value.snapshot
@@ -302,6 +323,7 @@ func Run(args []string) error {
 					state.review.LiveTree = value.snapshot.Tree
 				}
 				state.updateSource()
+				state.refreshAttention()
 				state.clampScroll()
 				state.queueContent(contentRequests)
 				dirty = true
@@ -375,6 +397,11 @@ func Run(args []string) error {
 
 			}
 		case <-renderTicker.C:
+			for _, a := range state.agents {
+				if a.attention.Quiet(time.Now()) {
+					dirty = true
+				}
+			}
 			if ui.WelcomeVisible(&state.review) && time.Since(lastWelcomeFrame) >= 250*time.Millisecond {
 				state.review.WelcomeFrame = (state.review.WelcomeFrame + 1) % 6
 				lastWelcomeFrame = time.Now()
@@ -390,6 +417,8 @@ func Run(args []string) error {
 				dirty = true
 			}
 			if dirty {
+				state.syncAttention()
+				state.resizeAgents()
 				if wantMouse := state.diffFocused || state.review.FooterFocused || state.agentPicker != nil; mouseEnabled != wantMouse {
 					mouseEnabled = wantMouse
 					if mouseEnabled {
@@ -420,6 +449,8 @@ func Run(args []string) error {
 type screenState struct {
 	agents                              []*agentTerminal
 	activeAgentIndex                    int
+	attentionPrevious                   *agentTerminal
+	agentSerial                         map[string]int
 	startAgent                          func([]string, ui.Layout) (*agentTerminal, error)
 	launchCommand                       []string
 	agentPicker                         *ui.AgentPicker
@@ -534,7 +565,7 @@ func (s *screenState) handleLegacyInput(data []byte, child io.Writer) {
 			child = s.agentInput
 			continue
 		}
-		if action == "Ctrl-]" || action == "Ctrl-N" || action == "Ctrl-P" || action == "Ctrl-W" {
+		if action == "Ctrl-]" || action == "Ctrl-N" || action == "Ctrl-P" || action == "Ctrl-W" || action == "Ctrl-Y" {
 			// Flush preceding text to its original terminal before switching.
 			if len(forward) > 0 {
 				_, _ = child.Write(forward)

--- a/internal/app/attention.go
+++ b/internal/app/attention.go
@@ -1,0 +1,214 @@
+package app
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/nccapo/stvena/internal/attention"
+	"github.com/nccapo/stvena/internal/diffview"
+	"github.com/nccapo/stvena/internal/review"
+)
+
+type attentionEvent struct {
+	agent  *agentTerminal
+	events []attention.Event
+}
+
+func watchAttention(a *agentTerminal, dir string, events chan<- any, stop <-chan struct{}) {
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			batch, err := attention.Drain(dir)
+			if err == nil && len(batch) > 0 {
+				select {
+				case events <- attentionEvent{a, batch}:
+				case <-stop:
+					return
+				case <-a.attentionStop:
+					return
+				}
+			}
+		case <-stop:
+			return
+		case <-a.attentionStop:
+			return
+		}
+	}
+}
+func (s *screenState) applyAttention(e attentionEvent) {
+	if e.agent.closed {
+		return
+	}
+	before := e.agent.attention.Priority()
+	for _, event := range e.events {
+		e.agent.attention.Apply(event)
+		for _, change := range event.Changes {
+			if e.agent.attention.Files[change.Path].At.Equal(event.At) {
+				delete(e.agent.reviewFiles, change.Path)
+			}
+		}
+	}
+	s.attentionChanged(e.agent, before)
+	s.refreshAttention()
+}
+
+// Review acknowledgement is version-specific and shared with the existing
+// file/hunk workflow. Merely selecting a terminal never acknowledges anything.
+func (s *screenState) refreshAttention() {
+	for _, a := range s.agents {
+		before := a.attention.Priority()
+		for path, item := range a.attention.Files {
+			if item.Reviewed {
+				continue
+			}
+			if s.sessionView.Err == nil && s.sessionView.Tree != "" && !s.sessionView.UpdatedAt.Before(item.At) {
+				found := false
+				for _, f := range s.sessionView.Files {
+					if f.Path == path || f.OldPath == path {
+						// The shared working copy may already include a later edit to this
+						// same file. Reviewing its current full diff covers both authors.
+						a.reviewFiles[path] = f
+						found = true
+						item.Ready = true
+						break
+					}
+				}
+				if !found && !s.sessionView.Approximate {
+					// An add followed by a delete (or a revert to the session baseline)
+					// can disappear between captures. Keep an explicit acknowledgement
+					// item instead of leaving CHANGED stuck with nothing to open.
+					a.reviewFiles[path] = diffview.File{Path: path, Scope: diffview.Session, Status: "M", AfterOID: item.Version,
+						Lines: []string{"Agent changed this path; no net changes remain since session start."}}
+					item.Ready = true
+				}
+			}
+			if f, ok := a.reviewFiles[path]; ok && item.Ready {
+				record := s.review.History[f.Key()]
+				item.Reviewed = !record.At.Before(item.At) && s.review.Reviewed(f)
+			}
+			a.attention.Files[path] = item
+		}
+		s.attentionChanged(a, before)
+	}
+	s.syncAttention()
+}
+func (s *screenState) attentionChanged(a *agentTerminal, before int) {
+	after := a.attention.Priority()
+	if before != after && (a == s.attentionPrevious || after < before && after <= 3) {
+		s.attentionPrevious = nil
+	}
+}
+
+func (s *screenState) syncAttention() {
+	s.review.Agents = nil
+	if s.agentSerial == nil {
+		s.agentSerial = map[string]int{}
+	}
+	for i, a := range s.agents {
+		if a.label == "" {
+			s.agentSerial[a.name]++
+			a.label = fmt.Sprintf("%s %d", a.name, s.agentSerial[a.name])
+		}
+		s.review.Agents = append(s.review.Agents, review.AgentSummary{
+			Label: a.label, State: a.attention, Active: i == s.activeAgentIndex,
+		})
+	}
+	if len(s.review.Agents) > 0 {
+		best := -1
+		for i, a := range s.agents {
+			if a.attention.Attention() != "idle" && (best < 0 || a.attention.Priority() < s.agents[best].attention.Priority()) {
+				best = i
+			}
+		}
+		if best >= 0 {
+			s.review.Agents[best].Next = true
+		}
+	}
+	// Labels have stable identities, so closing a terminal never renumbers it.
+	s.relayout(s.layout.Width, s.layout.Height)
+}
+func (s *screenState) nextAttention() {
+	var states []attention.State
+	previous := -1
+	for i, a := range s.agents {
+		states = append(states, a.attention)
+		if a == s.attentionPrevious {
+			previous = i
+		}
+	}
+	index := attention.Next(states, previous)
+	if index < 0 {
+		s.review.Notice = "No agents need attention"
+		return
+	}
+	a := s.agents[index]
+	s.selectAgent(index)
+	s.attentionPrevious = a
+	s.review.FooterFocused = false
+	if a.attention.Unreviewed() == 0 {
+		s.review.Notice = a.label + " · " + a.attention.Attention()
+		if a.attention.Execution == attention.Error && a.exited {
+			s.review.Notice += " · " + a.status
+		}
+		return
+	}
+	if s.review.Pinned || s.review.Prompt != "" || s.review.ConfirmAction != "" || s.review.Searching {
+		s.review.Notice = "Agent selected · finish or resume the current review to open its changes"
+		return
+	}
+	var files []diffview.File
+	for path, item := range a.attention.Files {
+		if !item.Reviewed {
+			if f, ok := a.reviewFiles[path]; ok {
+				files = append(files, f)
+			}
+		}
+	}
+	if len(files) == 0 {
+		s.review.Notice = "Agent selected · waiting for its captured changes"
+		return
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	// Select the relevant file in the normal session source, preserving editor
+	// opening, checkpoints and all existing review controls.
+	s.review.Source = "session"
+	s.review.Scope = 0
+	s.review.Query = ""
+	s.review.Help, s.review.Menu = false, false
+	s.review.Panel = ""
+	s.review.ClearSelection()
+	s.updateSource()
+	found := false
+	for i, index := range s.review.Indices {
+		if s.review.Snapshot.Files[index].Path == files[0].Path {
+			s.review.Selected = i
+			found = true
+			break
+		}
+	}
+	if !found {
+		snapshot := s.sessionView
+		snapshot.Files = files
+		snapshot.Label = a.label + " review"
+		snapshot.Finish()
+		latest := s.review.Latest
+		s.review.Update(snapshot)
+		s.review.Latest = latest
+		s.review.Pinned = true
+		s.review.PinnedVersion = latest.Version
+	}
+	s.review.Browser, s.review.FullFile = false, false
+	s.review.PatchFocused = true
+	s.review.Scroll = 0
+	for i, line := range s.review.DisplayLines() {
+		if line.Kind == '@' {
+			s.review.Scroll = i
+			break
+		}
+	}
+	s.diffFocused = true
+	s.review.Notice = fmt.Sprintf("%s · %d unreviewed files · %s: mark file reviewed", a.label, a.attention.Unreviewed(), review.KeyLabel(s.review.Binding(" ")))
+}

--- a/internal/app/attention_test.go
+++ b/internal/app/attention_test.go
@@ -1,0 +1,219 @@
+package app
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nccapo/stvena/internal/attention"
+	"github.com/nccapo/stvena/internal/diffview"
+	"github.com/nccapo/stvena/internal/session"
+)
+
+func attentionFile(path, body string) diffview.File {
+	return diffview.File{Path: path, Scope: diffview.Session, Status: "M", Added: 1, Deleted: 1, AfterOID: body, Lines: []string{"@@ -1 +1 @@", "-old", "+" + body}}
+}
+func TestBackgroundAgentReviewAcknowledgementAndIsolation(t *testing.T) {
+	s := terminalState(t)
+	a := s.activeAgent()
+	s.agentShortcut(0x1d)
+	s.agentPickerKey("l")
+	b := s.activeAgent()
+	s.selectAgent(0)
+	s.session = &session.Session{}
+	now := time.Now().Add(-time.Second)
+	s.applyAttention(attentionEvent{b, []attention.Event{{Kind: "PostToolUse", At: now, Changes: []attention.Change{{Path: "b.go", Version: "v1"}}}, {Kind: "Stop", At: now.Add(time.Millisecond)}}})
+	if s.activeAgent() != a || s.diffFocused || a.attention.Unreviewed() != 0 || b.attention.Review() != attention.Changed {
+		t.Fatal("background event leaked or stole focus")
+	}
+	f := attentionFile("b.go", "v1")
+	s.sessionView = diffview.Snapshot{Files: []diffview.File{f}, UpdatedAt: time.Now(), Tree: "tree"}
+	s.sessionView.Finish()
+	s.refreshAttention()
+	if b.attention.Attention() != "review_needed" || b.attention.Execution != attention.Completed {
+		t.Fatal(b.attention)
+	}
+	s.selectAgent(1)
+	s.refreshAttention()
+	if b.attention.Unreviewed() != 1 {
+		t.Fatal("opening terminal cleared review")
+	}
+	s.selectAgent(0)
+	s.handleInput([]byte{0x19}, s.agentInput)
+	if s.activeAgent() != b || !s.diffFocused || s.review.Current() == nil || s.review.Current().Path != "b.go" {
+		t.Fatal("next attention did not open relevant diff")
+	}
+	s.review.Key(" ", 20)
+	s.dispatch(context.Background(), make(chan any, 1), make(chan struct{}))
+	if b.attention.Review() != attention.Reviewed || b.attention.Attention() != "completed" {
+		t.Fatal("file acknowledgement did not clear", b.attention)
+	}
+	// A later edit by A to the same file must not reopen B's completed review.
+	s.applyAttention(attentionEvent{a, []attention.Event{{Kind: "PostToolUse", At: time.Now(), Changes: []attention.Change{{Path: "b.go", Version: "v2"}}}}})
+	s.sessionView.Files[0] = attentionFile("b.go", "v2")
+	s.sessionView.UpdatedAt = time.Now()
+	s.sessionView.Finish()
+	s.updateSource()
+	s.refreshAttention()
+	if a.attention.Unreviewed() != 1 || b.attention.Unreviewed() != 0 {
+		t.Fatal("later writer contaminated acknowledged owner")
+	}
+}
+func TestPinnedOldReviewCannotAcknowledgeNewChanges(t *testing.T) {
+	s := terminalState(t)
+	a := s.activeAgent()
+	now := time.Now().Add(-time.Second)
+	old := attentionFile("a.go", "v1")
+	s.sessionView = diffview.Snapshot{Files: []diffview.File{old}, UpdatedAt: now, Tree: "old"}
+	s.review.Source = "session"
+	s.review.Update(s.sessionView)
+	s.review.Pinned = true
+	s.applyAttention(attentionEvent{a, []attention.Event{{Kind: "PostToolUse", At: now.Add(time.Millisecond), Changes: []attention.Change{{Path: "a.go", Version: "v2"}}}}})
+	s.sessionView = diffview.Snapshot{Files: []diffview.File{attentionFile("a.go", "v2")}, UpdatedAt: time.Now(), Tree: "new"}
+	s.refreshAttention()
+	s.review.Key(" ", 20)
+	s.refreshAttention()
+	if a.attention.Unreviewed() != 1 {
+		t.Fatal("stale pinned acknowledgement cleared new version")
+	}
+	s.nextAttention()
+	if !s.review.Pinned || s.review.Snapshot.Tree != "old" {
+		t.Fatal("attention replaced pinned review")
+	}
+}
+func TestAllHunksAcknowledgeAttention(t *testing.T) {
+	s := terminalState(t)
+	a := s.activeAgent()
+	now := time.Now().Add(-time.Second)
+	f := attentionFile("a.go", "v1")
+	f.Lines = append(f.Lines, "@@ -8 +8 @@", "-old2", "+new2")
+	s.applyAttention(attentionEvent{a, []attention.Event{{Kind: "PostToolUse", At: now, Changes: []attention.Change{{Path: "a.go", Version: "v1"}}}}})
+	s.sessionView = diffview.Snapshot{Files: []diffview.File{f}, UpdatedAt: time.Now(), Tree: "tree"}
+	s.review.Source = "session"
+	s.review.Update(s.sessionView)
+	s.refreshAttention()
+	s.review.Key("H", 20)
+	s.refreshAttention()
+	if a.attention.Unreviewed() != 1 {
+		t.Fatal("one hunk cleared entire file")
+	}
+	s.review.Scroll = 3
+	s.review.Key("H", 20)
+	s.refreshAttention()
+	if a.attention.Unreviewed() != 0 {
+		t.Fatal("all hunks did not acknowledge file")
+	}
+}
+func TestAttentionRemappingAndQueueNavigation(t *testing.T) {
+	s := terminalState(t)
+	s.agentShortcut(0x1d)
+	s.agentPickerKey("l")
+	s.agentShortcut(0x1d)
+	s.agentPickerKey("c")
+	s.agents[0].attention.Execution = attention.Waiting
+	s.agents[1].attention.Execution = attention.Error
+	s.agents[2].attention.Execution = attention.Running
+	s.review.Hotkeys = map[string]string{"Ctrl-Y": "Ctrl-X"}
+	s.selectAgent(0)
+	s.handleInput([]byte{0x19}, s.agentInput)
+	if s.activeAgentIndex != 0 {
+		t.Fatal("old chord still active")
+	}
+	s.handleInput([]byte{0x18}, s.agentInput)
+	if s.activeAgentIndex != 1 {
+		t.Fatal("did not choose error")
+	}
+	s.handleInput([]byte{0x18}, s.agentInput)
+	if s.activeAgentIndex != 0 {
+		t.Fatal("did not cycle to waiting")
+	}
+	s.handleInput([]byte{0x18}, s.agentInput)
+	if s.activeAgentIndex != 2 {
+		t.Fatal("did not cycle to running")
+	}
+	s.agentShortcut(0x10)
+	s.activateFooter("next-attention")
+	if s.activeAgentIndex != 1 {
+		t.Fatal("manual navigation did not reset priority queue")
+	}
+}
+
+func TestRevertedBeforeCaptureStillHasReviewAcknowledgement(t *testing.T) {
+	s := terminalState(t)
+	a := s.activeAgent()
+	s.session = &session.Session{}
+	s.applyAttention(attentionEvent{a, []attention.Event{{Kind: "PostToolUse", At: time.Now().Add(-time.Second), Changes: []attention.Change{{Path: "gone.go", Version: "deleted"}}}}})
+	s.sessionView = diffview.Snapshot{Tree: "tree", UpdatedAt: time.Now()}
+	s.refreshAttention()
+	s.nextAttention()
+	if s.review.Current() == nil || s.review.Current().Path != "gone.go" || !s.review.Pinned {
+		t.Fatal("no acknowledgement for reverted change")
+	}
+	s.review.Key(" ", 20)
+	s.refreshAttention()
+	if a.attention.Unreviewed() != 0 {
+		t.Fatal("reverted change could not be acknowledged")
+	}
+}
+
+func TestCaptureStartedBeforeEditDoesNotMakeItReviewable(t *testing.T) {
+	s := terminalState(t)
+	a := s.activeAgent()
+	now := time.Now()
+	s.sessionView = diffview.Snapshot{Tree: "old", UpdatedAt: now.Add(-time.Second)}
+	s.applyAttention(attentionEvent{a, []attention.Event{{Kind: "PostToolUse", At: now, Changes: []attention.Change{{Path: "a.go", Version: "new"}}}}})
+	if a.attention.Review() != attention.Changed || len(a.reviewFiles) != 0 {
+		t.Fatal("older capture made new edit reviewable")
+	}
+	s.sessionView = diffview.Snapshot{Tree: "new", UpdatedAt: now.Add(time.Millisecond), Files: []diffview.File{attentionFile("a.go", "new")}}
+	s.refreshAttention()
+	if a.attention.Review() != attention.ReviewNeeded {
+		t.Fatal(a.attention)
+	}
+}
+
+func TestNewUrgentStateResetsAttentionCycle(t *testing.T) {
+	s := terminalState(t)
+	first := s.activeAgent()
+	s.agentShortcut(0x1d)
+	s.agentPickerKey("l")
+	second := s.activeAgent()
+	first.attention.Execution = attention.Running
+	second.attention.Execution = attention.Waiting
+	s.nextAttention()
+	if s.activeAgent() != second {
+		t.Fatal("waiting not selected")
+	}
+	s.applyAttention(attentionEvent{first, []attention.Event{{Kind: "StopFailure", At: time.Now()}}})
+	s.nextAttention()
+	if s.activeAgent() != first {
+		t.Fatal("new error skipped")
+	}
+	s.review.Browser = false
+	s.diffFocused = true
+	s.agentExited(first, nil)
+	if s.review.Browser || !s.diffFocused {
+		t.Fatal("exit interrupted review")
+	}
+}
+
+func TestRenamedPathsUseTheCapturedRenameDiff(t *testing.T) {
+	s := terminalState(t)
+	a := s.activeAgent()
+	s.session = &session.Session{}
+	s.applyAttention(attentionEvent{a, []attention.Event{{Kind: "PostToolUse", At: time.Now().Add(-time.Second), Changes: []attention.Change{{Path: "old.go", Version: "deleted"}, {Path: "new.go", Version: "new"}}}}})
+	f := attentionFile("new.go", "new")
+	f.OldPath = "old.go"
+	f.Status = "R"
+	s.sessionView = diffview.Snapshot{Tree: "tree", UpdatedAt: time.Now(), Files: []diffview.File{f}}
+	s.refreshAttention()
+	s.nextAttention()
+	if s.review.Pinned || a.reviewFiles["old.go"].OldPath != "old.go" {
+		t.Fatal("rename mistaken for no-net-change")
+	}
+	s.review.Key(" ", 20)
+	s.refreshAttention()
+	if a.attention.Unreviewed() != 0 {
+		t.Fatal("rename acknowledgement left old path pending")
+	}
+}

--- a/internal/app/footer.go
+++ b/internal/app/footer.go
@@ -43,8 +43,8 @@ func (s *screenState) activateFooter(key string) {
 	switch key {
 	case "focus":
 		s.switchPane()
-	case "new-agent", "next-agent", "previous-agent", "close-agent":
-		s.agentShortcut(map[string]byte{"new-agent": 0x1d, "next-agent": 0x0e, "previous-agent": 0x10, "close-agent": 0x17}[key])
+	case "new-agent", "next-agent", "previous-agent", "close-agent", "next-attention":
+		s.agentShortcut(map[string]byte{"new-agent": 0x1d, "next-agent": 0x0e, "previous-agent": 0x10, "close-agent": 0x17, "next-attention": 0x19}[key])
 	case "quit-app":
 		s.review.Request = key
 	default:

--- a/internal/app/keyboard.go
+++ b/internal/app/keyboard.go
@@ -109,7 +109,7 @@ func (s *screenState) flushKeyboardInput() {
 	}
 }
 
-// commandShortcut maps only the six global shortcuts. Unknown sequences and
+// commandShortcut maps the global shortcuts. Unknown sequences and
 // additional modifiers retain their original bytes; key releases are consumed.
 func commandShortcut(sequence []byte) (byte, bool) {
 	if !bytes.HasPrefix(sequence, []byte("\x1b[")) || sequence[len(sequence)-1] != 'u' {
@@ -142,6 +142,8 @@ func commandShortcut(sequence []byte) (byte, bool) {
 		control = 0x10
 	case 'w':
 		control = 0x17
+	case 'y':
+		control = 0x19
 	case 'q':
 		control = 0x11
 	default:

--- a/internal/app/terminals.go
+++ b/internal/app/terminals.go
@@ -2,12 +2,15 @@ package app
 
 import (
 	"fmt"
+	"github.com/nccapo/stvena/internal/attention"
+	"github.com/nccapo/stvena/internal/diffview"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/vt"
@@ -18,6 +21,10 @@ import (
 // Each command owns its screen and PTY. Only the event loop touches screen state.
 type agentTerminal struct {
 	name                          string
+	label                         string
+	attention                     attention.State
+	attentionStop                 chan struct{}
+	reviewFiles                   map[string]diffview.File
 	virtual                       *vt.Emulator
 	ptmx                          *os.File
 	input                         io.Writer
@@ -28,7 +35,7 @@ type agentTerminal struct {
 }
 
 func newAgentTerminal(name string, width, height int) *agentTerminal {
-	a := &agentTerminal{name: name, virtual: vt.NewEmulator(width, height), cursorVisible: true, status: "Running"}
+	a := &agentTerminal{name: name, attention: attention.State{Execution: attention.Idle}, virtual: vt.NewEmulator(width, height), cursorVisible: true, status: "Running", attentionStop: make(chan struct{}), reviewFiles: map[string]diffview.File{}}
 	// PTY output queued during resize can still specify the old scroll margins.
 	// Clamp before vt's default handlers store them and scroll outside the buffer.
 	// Remove when our vt version includes https://github.com/charmbracelet/x/pull/908.
@@ -102,6 +109,7 @@ func (s *screenState) activeAgent() *agentTerminal {
 }
 
 func (s *screenState) syncAgent() {
+	defer s.syncAttention()
 	if a := s.activeAgent(); a != nil {
 		s.agentInput, s.agentName = a.input, agentCommand(a.name)
 		s.exited, s.bracketedPaste = a.exited, a.bracketedPaste
@@ -119,6 +127,7 @@ func (s *screenState) selectAgent(index int) {
 	if a := s.activeAgent(); a != nil {
 		a.draft = s.review.AgentDraft
 	}
+	s.attentionPrevious = nil
 	s.activeAgentIndex = index
 	s.syncAgent()
 	if a := s.activeAgent(); a != nil {
@@ -136,7 +145,9 @@ func (s *screenState) agentShortcut(key byte) {
 		s.review.Notice = "Agent terminals are available when launching stvena with a command"
 		return
 	}
-	if key == 0x17 {
+	if key == 0x19 {
+		s.nextAttention()
+	} else if key == 0x17 {
 		s.closeActiveAgent()
 	} else if key == 0x1d {
 		s.pending = nil
@@ -220,7 +231,13 @@ func (s *screenState) agentExited(a *agentTerminal, err error) {
 	if a.closed {
 		return
 	}
+	before := a.attention.Priority()
+	a.attention.Exit(err != nil, time.Now())
+	s.attentionChanged(a, before)
 	a.exited, a.status = true, "Finished"
+	if a.attention.Execution == attention.Error {
+		a.status = "Turn failed"
+	}
 	if err != nil {
 		a.status = "Exited: " + err.Error()
 	}
@@ -228,9 +245,7 @@ func (s *screenState) agentExited(a *agentTerminal, err error) {
 		return
 	}
 	s.syncAgent()
-	s.diffFocused = true
-	s.review.Browser = true
-	s.review.Notice = "Agent finished · " + s.review.Binding("Ctrl-]") + ": new agent · " + s.review.Binding("Ctrl-N") + "/" + s.review.Binding("Ctrl-P") + ": switch agents"
+	s.review.Notice = a.status + " · " + s.review.Binding("Ctrl-]") + ": new agent · " + s.review.Binding("Ctrl-N") + "/" + s.review.Binding("Ctrl-P") + ": switch agents"
 	if !s.agentsRunning() {
 		s.review.Notice += " · q exits"
 	}

--- a/internal/app/terminals_integration_test.go
+++ b/internal/app/terminals_integration_test.go
@@ -11,8 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"encoding/json"
 	"github.com/charmbracelet/x/vt"
 	"github.com/creack/pty"
+	"github.com/nccapo/stvena/internal/attention"
 	"golang.org/x/term"
 )
 
@@ -32,6 +34,22 @@ func TestAgentTerminalsEndToEnd(t *testing.T) {
 				n, err := os.Stdin.Read(buffer)
 				if err != nil || strings.ContainsRune(string(buffer[:n]), '\x03') {
 					os.Exit(0)
+				}
+				if string(buffer[:n]) == "attention-edit" {
+					path := fmt.Sprintf("%s-%d.txt", kind, os.Getpid())
+					record := func(event string) {
+						data, _ := json.Marshal(map[string]any{"hook_event_name": event, "tool_name": "Write", "tool_use_id": "edit-1", "tool_input": map[string]string{"file_path": path}})
+						if err := attention.RecordHook(strings.NewReader(string(data))); err != nil {
+							fmt.Println(err)
+							os.Exit(2)
+						}
+					}
+					record("PreToolUse")
+					if err := os.WriteFile(path, []byte("agent-created change\n"), 0600); err != nil {
+						os.Exit(2)
+					}
+					record("PostToolUse")
+					record("Stop")
 				}
 				fmt.Printf("input:%d:%s\r\n", os.Getpid(), buffer[:n])
 			}
@@ -137,7 +155,7 @@ func exerciseAgentTerminals(t *testing.T, width int, helper string) {
 	send := func(text string) {
 		t.Helper()
 		if width == 140 {
-			text = strings.NewReplacer("\x07", "\x1b[103;9u", "\x1d", "\x1b[93;9u", "\x0e", "\x1b[110;9u", "\x10", "\x1b[112;9u", "\x17", "\x1b[119;9u", "\x11", "\x1b[113;9u").Replace(text)
+			text = strings.NewReplacer("\x07", "\x1b[103;9u", "\x1d", "\x1b[93;9u", "\x0e", "\x1b[110;9u", "\x10", "\x1b[112;9u", "\x17", "\x1b[119;9u", "\x11", "\x1b[113;9u", "\x19", "\x1b[121;9u").Replace(text)
 		}
 		if _, err := ptmx.WriteString(text); err != nil {
 			t.Fatal(err)
@@ -170,7 +188,7 @@ func exerciseAgentTerminals(t *testing.T, width int, helper string) {
 	send("\x1d")
 	waitFor("New agent")
 	send("l")
-	waitFor("claude 2/2")
+	waitFor("[claude 1 ")
 	text := screen()
 	if !strings.Contains(text, "ready:") {
 		text = waitFor("ready:")
@@ -185,22 +203,23 @@ func exerciseAgentTerminals(t *testing.T, width int, helper string) {
 	send("second")
 	waitFor("input:" + second + ":second")
 	send("\x10")
-	text = waitFor(filepath.Base(executable) + " 1/2")
+	text = waitFor("[" + filepath.Base(executable) + " 1 ")
 	if !strings.Contains(text, "input:"+first+":first") || strings.Contains(text, "input:"+second) {
 		t.Fatal("switch did not restore the first terminal's screen")
 	}
 	// Interrupting one command must leave the other usable, and q must not
 	// accidentally stop it while viewing the finished command.
 	send("\x03")
-	waitFor("Finished")
+	waitFor("✓ DONE")
+	send("\x0f")
 	send("q")
 	waitFor("An agent is still running")
 	send("\x0e")
-	waitFor("claude 2/2")
+	waitFor("[claude 1 ")
 	send("alive")
 	waitFor("input:" + second + ":alive")
 	send("\x1dc")
-	waitFor("codex 3/3")
+	waitFor("[codex 1 ")
 	text = screen()
 	if !strings.Contains(text, "ready:") {
 		text = waitFor("ready:")
@@ -209,8 +228,22 @@ func exerciseAgentTerminals(t *testing.T, width int, helper string) {
 	if !strings.Contains(text, "kind:codex") {
 		t.Fatal("chooser did not launch Codex")
 	}
+	// Codex creates changes while Claude is selected. No manual inspection of
+	// the Codex pane should be needed to discover or acknowledge its review.
+	send("attention-edit\x10")
+	waitFor("! REVIEW 1f")
+	if !strings.Contains(screen(), "[claude 1 ") {
+		t.Fatal("background edit stole focus")
+	}
+	send("\x19")
+	waitFor("agent-created change")
+	if !strings.Contains(screen(), "codex 1 ! REVIEW 1f") {
+		t.Fatal("next attention missed Codex")
+	}
+	send(" ")
+	waitFor("Review:0")
 	send("\x17")
-	waitFor("claude 2/2")
+	waitFor("[claude 1 ")
 	var closedPID int
 	_, _ = fmt.Sscan(third, &closedPID)
 	if err := syscall.Kill(closedPID, 0); err != syscall.ESRCH {
@@ -220,11 +253,11 @@ func exerciseAgentTerminals(t *testing.T, width int, helper string) {
 	waitFor("input:" + second + ":survived")
 	// Remove the finished terminal, then the last running terminal.
 	send("\x10\x17")
-	waitFor("claude 1/1")
+	waitFor("[claude 1 ")
 	send("\x17")
 	waitFor("q exits")
 	send("\x1d\r")
-	waitFor(filepath.Base(executable) + " 1/1")
+	waitFor("[" + filepath.Base(executable) + " 2 ")
 	text = screen()
 	if !strings.Contains(text, "ready:") {
 		text = waitFor("ready:")

--- a/internal/app/workspace.go
+++ b/internal/app/workspace.go
@@ -31,6 +31,7 @@ func watchSnapshots(root string, rootErr error, saved *session.Session, events c
 	bridgeReported := false
 	var project diffview.Snapshot
 	refresh := func() {
+		capturedAt := time.Now()
 		tree, err := saved.Capture()
 		workspace := diffview.Collect(root)
 		workspace.Label = "Workspace"
@@ -50,6 +51,9 @@ func watchSnapshots(root string, rootErr error, saved *session.Session, events c
 		if err == nil && (project.Tree != tree || project.Err != nil) {
 			project = diffview.Project(root, tree)
 		}
+		// Attention events must compare against when the tree was captured, not
+		// when the subsequent Git diff finished processing an older tree.
+		view.UpdatedAt = capturedAt
 		deliveredProject := project
 		if err != nil {
 			deliveredProject.Err = fmt.Errorf("Project capture failed: %w", err)
@@ -128,6 +132,7 @@ func (s *screenState) setCheck(r checks.Result) {
 	s.review.CheckLines = strings.Split(r.Command+"\nSnapshot: "+r.Tree+"\n"+s.review.CheckStatus+fmt.Sprintf(" (exit %d)", r.ExitCode)+" · "+r.FinishedAt.Format(time.RFC3339)+"\n\n"+r.Output, "\n")
 }
 func (s *screenState) dispatch(ctx context.Context, events chan<- any, stop <-chan struct{}) bool {
+	defer s.refreshAttention()
 	if s.review.HotkeysDirty {
 		s.relayout(s.layout.Width, s.layout.Height)
 		if err := s.savePreferences(); err != nil {

--- a/internal/attention/hooks.go
+++ b/internal/attention/hooks.go
@@ -1,0 +1,190 @@
+package attention
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nccapo/stvena/internal/session"
+)
+
+// RecordHook stores only lifecycle metadata and explicit edit paths, never
+// prompts or command output. Atomic event files avoid losing rapid transitions.
+func RecordHook(input io.Reader) error {
+	dir, root := os.Getenv("STVENA_ATTENTION_DIR"), os.Getenv("STVENA_ROOT")
+	if dir == "" || root == "" {
+		return nil
+	}
+	var h struct {
+		Kind         string `json:"hook_event_name"`
+		ID           string `json:"tool_use_id"`
+		CWD          string `json:"cwd"`
+		Tool         string `json:"tool_name"`
+		Notification string `json:"notification_type"`
+		Input        struct {
+			File    string `json:"file_path"`
+			Path    string `json:"path"`
+			Command string `json:"command"`
+		} `json:"tool_input"`
+	}
+	if err := json.NewDecoder(io.LimitReader(input, 1024*1024)).Decode(&h); err != nil {
+		return err
+	}
+	e := Event{Kind: h.Kind, At: time.Now().UTC()}
+	switch h.Kind {
+	case "SessionStart", "UserPromptSubmit", "Stop", "StopFailure", "PreToolUse", "PostToolUse", "PostToolUseFailure":
+	case "Notification":
+		if h.Notification != "permission_prompt" && h.Notification != "idle_prompt" {
+			return nil
+		}
+		e.Kind = "waiting"
+	default:
+		return nil
+	}
+	var paths []string
+	switch h.Tool {
+	case "Edit", "Write", "MultiEdit":
+		p := h.Input.File
+		if p == "" {
+			p = h.Input.Path
+		}
+		if p != "" {
+			paths = append(paths, p)
+		}
+	case "apply_patch":
+		for _, line := range strings.Split(h.Input.Command, "\n") {
+			for _, prefix := range []string{"*** Add File: ", "*** Update File: ", "*** Delete File: ", "*** Move to: "} {
+				if strings.HasPrefix(line, prefix) {
+					paths = append(paths, strings.TrimPrefix(line, prefix))
+				}
+			}
+		}
+	}
+	beforePath := filepath.Join(dir, fmt.Sprintf("tool-%x.json", sha256.Sum256([]byte(h.ID))))
+	if h.ID != "" && h.Kind == "PreToolUse" && len(paths) > 0 {
+		before := map[string]string{}
+		for _, p := range paths {
+			if rel := safePath(root, h.CWD, p); rel != "" && !ignored(root, rel) {
+				if v, err := fileVersion(root, rel); err == nil {
+					before[rel] = v
+				}
+			}
+		}
+		if err := session.AtomicJSON(beforePath, before); err != nil {
+			return err
+		}
+	}
+	if h.ID != "" && (h.Kind == "PostToolUse" || h.Kind == "PostToolUseFailure") {
+		var before map[string]string
+		if data, err := os.ReadFile(beforePath); h.Kind == "PostToolUse" && err == nil && json.Unmarshal(data, &before) == nil {
+			for p, old := range before {
+				if v, err := fileVersion(root, p); err == nil && v != old {
+					e.Changes = append(e.Changes, Change{p, v})
+				}
+			}
+		}
+		_ = os.Remove(beforePath)
+	}
+	file, err := os.CreateTemp(dir, ".event-*.json")
+	if err != nil {
+		return err
+	}
+	temp := file.Name()
+	name := filepath.Join(dir, strings.TrimPrefix(filepath.Base(temp), "."))
+	_ = file.Close()
+	_ = os.Remove(temp)
+	return session.AtomicJSON(name, e)
+}
+
+func safePath(root, cwd, path string) string {
+	realRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return ""
+	}
+	if cwd == "" {
+		cwd = root
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(cwd, path)
+	}
+	// Resolve the closest existing ancestor to support additions and deletions.
+	tail := ""
+	current := filepath.Clean(path)
+	for {
+		resolved, e := filepath.EvalSymlinks(current)
+		if e == nil {
+			path = filepath.Join(resolved, tail)
+			break
+		}
+		if !os.IsNotExist(e) || filepath.Dir(current) == current {
+			return ""
+		}
+		tail = filepath.Join(filepath.Base(current), tail)
+		current = filepath.Dir(current)
+	}
+	rel, err := filepath.Rel(realRoot, path)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".git" || strings.HasPrefix(rel, ".git"+string(filepath.Separator)) {
+		return ""
+	}
+	return filepath.ToSlash(rel)
+}
+func ignored(root, path string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	return exec.CommandContext(ctx, "git", "-C", root, "check-ignore", "--quiet", "--", path).Run() == nil
+}
+
+func fileVersion(root, path string) (string, error) {
+	if safePath(root, root, path) != path {
+		return "", fmt.Errorf("path outside workspace")
+	}
+	info, err := os.Lstat(filepath.Join(root, path))
+	if os.IsNotExist(err) {
+		return "deleted", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("not a regular file")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "git", "-C", root, "hash-object", "--", path).Output()
+	return strings.TrimSpace(string(out)), err
+}
+
+// Drain is run off the render loop. Tool baselines stay until their post event.
+func Drain(dir string) ([]Event, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var events []Event
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), "event-") || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		name := filepath.Join(dir, entry.Name())
+		data, err := os.ReadFile(name)
+		if err != nil {
+			return nil, err
+		}
+		var e Event
+		if json.Unmarshal(data, &e) == nil {
+			events = append(events, e)
+		}
+		_ = os.Remove(name)
+	}
+	// Filename randomness is deliberate; lifecycle order comes from hook time.
+	sort.SliceStable(events, func(i, j int) bool { return events[i].At.Before(events[j].At) })
+	return events, nil
+}

--- a/internal/attention/hooks_test.go
+++ b/internal/attention/hooks_test.go
@@ -1,0 +1,169 @@
+package attention
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func hookRepo(t *testing.T) (string, string) {
+	t.Helper()
+	root, dir := t.TempDir(), t.TempDir()
+	if out, err := exec.Command("git", "init", "-q", root).CombinedOutput(); err != nil {
+		t.Fatal(err, string(out))
+	}
+	t.Setenv("STVENA_ROOT", root)
+	t.Setenv("STVENA_ATTENTION_DIR", dir)
+	return root, dir
+}
+func hook(t *testing.T, kind, tool, id string, input map[string]any) {
+	t.Helper()
+	data, _ := json.Marshal(map[string]any{"hook_event_name": kind, "tool_name": tool, "tool_use_id": id, "tool_input": input})
+	if err := RecordHook(strings.NewReader(string(data))); err != nil {
+		t.Fatal(err)
+	}
+}
+func TestHooksAttributeOnlyExplicitChangedFiles(t *testing.T) {
+	root, dir := hookRepo(t)
+	write := func(p, text string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(root, p), []byte(text), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("a.go", "before")
+	write("b.go", "before")
+	hook(t, "PreToolUse", "Edit", "a", map[string]any{"file_path": "a.go"})
+	hook(t, "PreToolUse", "Read", "b", map[string]any{"file_path": "b.go"})
+	write("a.go", "after")
+	write("b.go", "external edit")
+	hook(t, "PostToolUse", "Edit", "a", nil)
+	hook(t, "PostToolUse", "Read", "b", nil)
+	hook(t, "Stop", "", "", nil)
+	events, err := Drain(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var changes []Change
+	for _, e := range events {
+		changes = append(changes, e.Changes...)
+	}
+	if len(events) != 5 || len(changes) != 1 || changes[0].Path != "a.go" {
+		t.Fatal(events)
+	}
+	if events[len(events)-1].Kind != "Stop" {
+		t.Fatal("lifecycle out of order")
+	}
+	if events, err := Drain(dir); err != nil || len(events) != 0 {
+		t.Fatal("events replayed", events, err)
+	}
+}
+func TestPatchAddDeleteRenameAndNoOp(t *testing.T) {
+	root, dir := hookRepo(t)
+	if err := os.WriteFile(filepath.Join(root, "old.go"), []byte("before"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	patch := "*** Begin Patch\n*** Update File: old.go\n*** Move to: new.go\n@@\n-before\n+after\n*** Add File: added.go\n+added\n*** End Patch"
+	hook(t, "PreToolUse", "apply_patch", "patch", map[string]any{"command": patch})
+	for _, p := range []string{"new.go", "added.go"} {
+		if err := os.WriteFile(filepath.Join(root, p), []byte("after"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Remove(filepath.Join(root, "old.go")); err != nil {
+		t.Fatal(err)
+	}
+	hook(t, "PostToolUse", "apply_patch", "patch", nil)
+	hook(t, "PreToolUse", "Write", "noop", map[string]any{"file_path": "new.go"})
+	hook(t, "PostToolUse", "Write", "noop", nil)
+	events, _ := Drain(dir)
+	n := 0
+	for _, e := range events {
+		n += len(e.Changes)
+	}
+	if n != 3 {
+		t.Fatal(events)
+	}
+}
+func TestHookPathsAndNotifications(t *testing.T) {
+	root, dir := hookRepo(t)
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "link")); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{"../outside", "link/new.go", ".git/config", outside} {
+		if got := safePath(root, root, path); got != "" {
+			t.Fatal(path, got)
+		}
+	}
+	if got := safePath(root, root, "new/child.go"); got != "new/child.go" {
+		t.Fatal(got)
+	}
+	for _, kind := range []string{"permission_prompt", "idle_prompt", "auth_success"} {
+		if err := RecordHook(strings.NewReader(`{"hook_event_name":"Notification","notification_type":"` + kind + `"}`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	events, _ := Drain(dir)
+	if len(events) != 2 || events[0].Kind != "waiting" {
+		t.Fatal(events)
+	}
+}
+func TestSeparateTerminalEventDirectories(t *testing.T) {
+	root, a := hookRepo(t)
+	b := t.TempDir()
+	hook(t, "PreToolUse", "Write", "same-id", map[string]any{"file_path": "a.go"})
+	t.Setenv("STVENA_ATTENTION_DIR", b)
+	hook(t, "PreToolUse", "Read", "same-id", map[string]any{"file_path": "a.go"})
+	if err := os.WriteFile(filepath.Join(root, "a.go"), []byte("new"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	hook(t, "PostToolUse", "Read", "same-id", nil)
+	t.Setenv("STVENA_ATTENTION_DIR", a)
+	hook(t, "PostToolUse", "Write", "same-id", nil)
+	ea, _ := Drain(a)
+	eb, _ := Drain(b)
+	if len(ea[1].Changes) != 1 || len(eb[1].Changes) != 0 {
+		t.Fatal(ea, eb)
+	}
+}
+
+func TestIgnoredFilesDoNotBecomeUnreviewableItems(t *testing.T) {
+	root, dir := hookRepo(t)
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("ignored.txt\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	hook(t, "PreToolUse", "Write", "ignored", map[string]any{"file_path": "ignored.txt"})
+	if err := os.WriteFile(filepath.Join(root, "ignored.txt"), []byte("ignored"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	hook(t, "PostToolUse", "Write", "ignored", nil)
+	events, _ := Drain(dir)
+	for _, e := range events {
+		if len(e.Changes) > 0 {
+			t.Fatal(events)
+		}
+	}
+}
+
+func TestFailedEditDoesNotClaimAnotherWritersChanges(t *testing.T) {
+	root, dir := hookRepo(t)
+	hook(t, "PreToolUse", "Edit", "failed", map[string]any{"file_path": "a.go"})
+	if err := os.WriteFile(filepath.Join(root, "a.go"), []byte("another agent wrote this"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	hook(t, "PostToolUseFailure", "Edit", "failed", nil)
+	events, _ := Drain(dir)
+	for _, e := range events {
+		if len(e.Changes) > 0 {
+			t.Fatal(events)
+		}
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) > 0 {
+		t.Fatal("tool baseline leaked", entries)
+	}
+}

--- a/internal/attention/state.go
+++ b/internal/attention/state.go
@@ -1,0 +1,185 @@
+// Package attention owns agent execution and human review state, independently
+// of the terminal renderer. The application's event loop is its only writer.
+package attention
+
+import (
+	"sort"
+	"time"
+)
+
+type Execution string
+
+const (
+	Idle      Execution = "idle"
+	Running   Execution = "running"
+	Waiting   Execution = "waiting"
+	Completed Execution = "completed"
+	Error     Execution = "error"
+)
+
+type Review string
+
+const (
+	Clean        Review = "clean"
+	Changed      Review = "changed"
+	ReviewNeeded Review = "review_needed"
+	Reviewed     Review = "reviewed"
+)
+
+type Change struct {
+	Path    string `json:"path"`
+	Version string `json:"version"`
+}
+type Event struct {
+	Kind    string    `json:"kind"`
+	At      time.Time `json:"at"`
+	Changes []Change  `json:"changes,omitempty"`
+}
+type File struct {
+	Version         string
+	At              time.Time
+	Ready, Reviewed bool
+}
+type State struct {
+	Execution      Execution
+	LastActivity   time.Time
+	Files          map[string]File
+	Hooked, Exited bool
+	lastHook       time.Time
+}
+
+func (s *State) Apply(e Event) {
+	if s.Files == nil {
+		s.Files = map[string]File{}
+	}
+	for _, c := range e.Changes {
+		old, ok := s.Files[c.Path]
+		if !ok || !e.At.Before(old.At) {
+			s.Files[c.Path] = File{Version: c.Version, At: e.At}
+		}
+	}
+	if s.Exited || e.At.Before(s.lastHook) {
+		return
+	}
+	s.Hooked = s.Hooked || e.Kind != "SessionStart"
+	s.lastHook = e.At
+	if e.At.After(s.LastActivity) {
+		s.LastActivity = e.At
+	}
+	switch e.Kind {
+	case "SessionStart":
+		s.Execution = Idle
+	case "UserPromptSubmit", "PreToolUse", "PostToolUse", "PostToolUseFailure":
+		s.Execution = Running
+	case "waiting":
+		s.Execution = Waiting
+	case "Stop":
+		if s.Execution != Error {
+			s.Execution = Completed
+		}
+	case "StopFailure":
+		s.Execution = Error
+	}
+}
+func (s *State) Output(now time.Time) {
+	if s.Exited {
+		return
+	}
+	if now.After(s.LastActivity) {
+		s.LastActivity = now
+	}
+	// Once turn events arrive, prompt redraws cannot restart a finished turn.
+	if !s.Hooked {
+		s.Execution = Running
+	}
+}
+
+func (s *State) Quiet(now time.Time) bool {
+	// Silence means only no observed activity, never completion or user input.
+	if !s.Hooked && !s.Exited && s.Execution == Running && now.Sub(s.LastActivity) > 3*time.Second {
+		s.Execution = Idle
+		return true
+	}
+	return false
+}
+func (s *State) Exit(failed bool, now time.Time) {
+	failed = failed || s.Execution == Error
+	s.Exited, s.LastActivity, s.Execution = true, now, Completed
+	if failed {
+		s.Execution = Error
+	}
+}
+func (s State) Review() Review {
+	if len(s.Files) == 0 {
+		return Clean
+	}
+	for _, f := range s.Files {
+		if !f.Reviewed && f.Ready {
+			return ReviewNeeded
+		}
+	}
+	for _, f := range s.Files {
+		if !f.Reviewed {
+			return Changed
+		}
+	}
+	return Reviewed
+}
+func (s State) Unreviewed() int {
+	n := 0
+	for _, f := range s.Files {
+		if !f.Reviewed {
+			n++
+		}
+	}
+	return n
+}
+func (s State) Attention() string {
+	if s.Execution == Error {
+		return "error"
+	}
+	r := s.Review()
+	if r == ReviewNeeded {
+		return string(r)
+	}
+	if s.Execution == Waiting {
+		return "waiting"
+	}
+	if r == Changed {
+		return string(r)
+	}
+	if s.Execution == "" {
+		return "idle"
+	}
+	return string(s.Execution)
+}
+func (s State) Priority() int {
+	return map[string]int{"error": 0, "review_needed": 1, "waiting": 2, "changed": 3, "running": 4, "completed": 5, "idle": 6}[s.Attention()]
+}
+
+// Order is stable within each priority. Idle sessions are not attention targets.
+func Order(states []State) []int {
+	var order []int
+	for i, s := range states {
+		if s.Attention() != "idle" {
+			order = append(order, i)
+		}
+	}
+	sort.SliceStable(order, func(i, j int) bool { return states[order[i]].Priority() < states[order[j]].Priority() })
+	return order
+}
+
+// Next begins at the highest priority, then walks the queue on repeated presses.
+// The caller resets previous when the user navigates normally.
+func Next(states []State, previous int) int {
+	order := Order(states)
+	if len(order) == 0 {
+		return -1
+	}
+	for i, index := range order {
+		if index == previous {
+			return order[(i+1)%len(order)]
+		}
+	}
+	return order[0]
+}

--- a/internal/attention/state_test.go
+++ b/internal/attention/state_test.go
@@ -1,0 +1,127 @@
+package attention
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestExecutionAndReviewTransitions(t *testing.T) {
+	now := time.Now()
+	s := State{}
+	if s.Attention() != "idle" {
+		t.Fatal(s)
+	}
+	s.Output(now)
+	if s.Execution != Running {
+		t.Fatal(s)
+	}
+	// Structured stop wins even if terminal output was received after the hook.
+	s.Apply(Event{Kind: "Stop", At: now.Add(-time.Millisecond)})
+	if s.Execution != Completed {
+		t.Fatal(s)
+	}
+	s.Output(now.Add(time.Second))
+	if s.Execution != Completed {
+		t.Fatal("redraw restarted turn")
+	}
+	s.Apply(Event{Kind: "UserPromptSubmit", At: now.Add(time.Second)})
+	s.Apply(Event{Kind: "PostToolUse", At: now.Add(2 * time.Second), Changes: []Change{{"a.go", "v1"}}})
+	if s.Execution != Running || s.Review() != Changed || s.Unreviewed() != 1 {
+		t.Fatal(s)
+	}
+	f := s.Files["a.go"]
+	f.Ready = true
+	s.Files["a.go"] = f
+	if s.Attention() != "review_needed" || s.Execution != Running {
+		t.Fatal(s)
+	}
+	s.Apply(Event{Kind: "Stop", At: now.Add(3 * time.Second)})
+	if s.Attention() != "review_needed" || s.Execution != Completed {
+		t.Fatal(s)
+	}
+	f.Reviewed = true
+	s.Files["a.go"] = f
+	if s.Review() != Reviewed || s.Attention() != "completed" {
+		t.Fatal(s)
+	}
+	s.Apply(Event{Kind: "UserPromptSubmit", At: now.Add(4 * time.Second)})
+	s.Exit(true, now.Add(5*time.Second))
+	if s.Attention() != "error" {
+		t.Fatal(s)
+	}
+	s.Apply(Event{Kind: "Stop", At: now.Add(6 * time.Second)})
+	if s.Attention() != "error" {
+		t.Fatal("late hook revived exited process")
+	}
+}
+func TestQuietDoesNotInventWaitingOrCompletion(t *testing.T) {
+	now := time.Now()
+	s := State{}
+	s.Output(now)
+	if !s.Quiet(now.Add(4*time.Second)) || s.Execution != Idle {
+		t.Fatal(s)
+	}
+	s.Apply(Event{Kind: "PreToolUse", At: now.Add(5 * time.Second)})
+	if s.Quiet(now.Add(time.Hour)) || s.Execution != Running {
+		t.Fatal("quiet interrupted known work")
+	}
+	s.Apply(Event{Kind: "waiting", At: now.Add(6 * time.Second)})
+	if s.Attention() != "waiting" {
+		t.Fatal(s)
+	}
+	s.Apply(Event{Kind: "PreToolUse", At: now.Add(7 * time.Second)})
+	if s.Execution != Running {
+		t.Fatal(s)
+	}
+}
+func TestAttentionQueuePriorityAndCycling(t *testing.T) {
+	states := []State{{Execution: Running}, {Execution: Completed}, {Execution: Waiting}, {Execution: Error}, {Files: map[string]File{"a": {Ready: true}}}, {Files: map[string]File{"b": {}}}, {Execution: Idle}}
+	if got := Order(states); !reflect.DeepEqual(got, []int{3, 4, 2, 5, 0, 1}) {
+		t.Fatal(got)
+	}
+	previous := -1
+	for _, want := range []int{3, 4, 2, 5, 0, 1, 3} {
+		previous = Next(states, previous)
+		if previous != want {
+			t.Fatalf("got %d want %d", previous, want)
+		}
+	}
+	if Next([]State{{Execution: Idle}}, -1) != -1 {
+		t.Fatal("idle in queue")
+	}
+}
+func TestLateEventsAndSessionIsolation(t *testing.T) {
+	now := time.Now()
+	a, b := State{}, State{}
+	a.Apply(Event{Kind: "PostToolUse", At: now, Changes: []Change{{"a", "new"}}})
+	a.Apply(Event{Kind: "PreToolUse", At: now.Add(-time.Second), Changes: []Change{{"a", "old"}}})
+	if a.Files["a"].Version != "new" || b.Unreviewed() != 0 {
+		t.Fatal(a, b)
+	}
+	a.Exit(false, now.Add(time.Second))
+	a.Apply(Event{Kind: "PostToolUse", At: now.Add(time.Millisecond), Changes: []Change{{"b", "last"}}})
+	if a.Execution != Completed || a.Unreviewed() != 2 {
+		t.Fatal("late changes lost at exit", a)
+	}
+}
+
+func TestTurnFailurePersistsUntilNewWork(t *testing.T) {
+	now := time.Now()
+	s := State{}
+	s.Apply(Event{Kind: "StopFailure", At: now})
+	s.Apply(Event{Kind: "Stop", At: now.Add(time.Millisecond)})
+	if s.Execution != Error {
+		t.Fatal("Stop hid failure")
+	}
+	s.Exit(false, now.Add(2*time.Millisecond))
+	if s.Execution != Error {
+		t.Fatal("clean process exit hid turn failure")
+	}
+	s = State{}
+	s.Apply(Event{Kind: "StopFailure", At: now})
+	s.Apply(Event{Kind: "UserPromptSubmit", At: now.Add(time.Second)})
+	if s.Execution != Running {
+		t.Fatal("new turn did not recover")
+	}
+}

--- a/internal/editor/activity.go
+++ b/internal/editor/activity.go
@@ -42,21 +42,28 @@ func HookArgs(args []string, executable string) []string {
 	name := filepath.Base(args[0])
 	command := "'" + strings.ReplaceAll(executable, "'", "'\"'\"'") + "' editor-hook"
 	extra := []string{}
+	events := []string{"PostToolUse", "PreToolUse", "SessionStart", "UserPromptSubmit", "Stop"}
 	switch name {
 	case "codex":
-		extra = []string{"-c", "hooks.PostToolUse=[{matcher=\"Bash|Read\",hooks=[{type=\"command\",command=" + strconv.Quote(command) + ",timeout=2}]}]"}
+		for _, event := range events {
+			extra = append(extra, "-c", "hooks."+event+"=[{hooks=[{type=\"command\",command="+strconv.Quote(command)+",timeout=2}]}]")
+		}
 	case "claude":
 		for _, arg := range args[1:] {
 			if arg == "--settings" || strings.HasPrefix(arg, "--settings=") {
 				return args
 			}
 		}
-		config := map[string]any{"hooks": map[string]any{"PostToolUse": []any{map[string]any{"matcher": "Read|Bash", "hooks": []any{map[string]any{"type": "command", "command": command, "timeout": 2}}}}}}
-		data, _ := json.Marshal(config)
+		hooks := map[string]any{}
+		for _, event := range append(events, "Notification", "StopFailure", "PostToolUseFailure") {
+			hooks[event] = []any{map[string]any{"hooks": []any{map[string]any{"type": "command", "command": command, "timeout": 2}}}}
+		}
+		data, _ := json.Marshal(map[string]any{"hooks": hooks})
 		extra = []string{"--settings", string(data)}
 	default:
 		return args
 	}
+
 	return append(append([]string{args[0]}, extra...), args[1:]...)
 }
 

--- a/internal/editor/activity_test.go
+++ b/internal/editor/activity_test.go
@@ -90,7 +90,7 @@ func TestRecordHook(t *testing.T) {
 func TestHookArgs(t *testing.T) {
 	args := []string{"codex", "resume", "--last"}
 	got := HookArgs(args, "/tmp/agent's dir/stvena")
-	if got[1] != "-c" || !strings.Contains(got[2], "hooks.PostToolUse") || !reflect.DeepEqual(got[3:], args[1:]) {
+	if got[1] != "-c" || !strings.Contains(got[2], "hooks.PostToolUse") || !reflect.DeepEqual(got[len(got)-len(args)+1:], args[1:]) {
 		t.Fatal(got)
 	}
 	claude := HookArgs([]string{"claude", "--resume"}, "/tmp/stvena")

--- a/internal/review/global_hotkeys.go
+++ b/internal/review/global_hotkeys.go
@@ -8,6 +8,7 @@ var GlobalHotkeyActions = []Action{
 	{"Ctrl-]", "New agent", "Choose a command for another agent terminal"},
 	{"Ctrl-N", "Next agent", "Select the next agent terminal"},
 	{"Ctrl-P", "Previous agent", "Select the previous agent terminal"},
+	{"Ctrl-Y", "Next attention", "Cycle agents by error, review, waiting, changes, running, done"},
 	{"Ctrl-W", "Close agent", "Stop and close the current agent terminal"},
 	{"Ctrl-Q", "Quit all", "Close Stvena and stop all running agents"},
 }

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -7,13 +7,21 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/nccapo/stvena/internal/attention"
 	"github.com/nccapo/stvena/internal/checks"
 	"github.com/nccapo/stvena/internal/diffview"
 )
 
 var Scopes = []diffview.Scope{"", diffview.Staged, diffview.Unstaged, diffview.Untracked}
 
+type AgentSummary struct {
+	Label        string
+	State        attention.State
+	Active, Next bool
+}
+
 type State struct {
+	Agents                            []AgentSummary
 	Snapshot                          diffview.Snapshot
 	Indices                           []int
 	Selected, Scroll, Horizontal      int

--- a/internal/ui/attention.go
+++ b/internal/ui/attention.go
@@ -1,0 +1,121 @@
+package ui
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/nccapo/stvena/internal/attention"
+	"github.com/nccapo/stvena/internal/review"
+)
+
+func agentBadge(a review.AgentSummary) string {
+	label, style := "· IDLE", muted
+	switch a.State.Attention() {
+	case "error":
+		label, style = "× ERROR", red
+	case "review_needed":
+		label, style = "! REVIEW", yellow
+	case "waiting":
+		label, style = "? WAITING", yellow
+	case "changed":
+		label, style = "+ CHANGED", yellow
+	case "running":
+		label, style = "● RUNNING", cyan
+	case "completed":
+		label, style = "✓ DONE", green
+	}
+	if n := a.State.Unreviewed(); n > 0 {
+		label += fmt.Sprintf(" %df", n)
+	}
+	// Execution remains visible when review takes priority.
+	if a.State.Execution == attention.Running && a.State.Attention() != "running" {
+		label += " / RUN"
+	}
+	prefix := ""
+	if a.Next {
+		prefix = "→"
+	}
+	text := prefix + safeText(a.Label) + " " + style + label + reset
+	if a.Active {
+		text = "[" + bold + text + "]" + reset
+	}
+	return text
+}
+
+// Two calm rows at most. On overflow keep the active and highest priority
+// terminals visible and state how many others can be reached by navigation.
+func agentRows(s *review.State, width int) []string {
+	if len(s.Agents) == 0 {
+		return nil
+	}
+	// Choose which terminals fit by attention first, retaining active context.
+	order := make([]int, len(s.Agents))
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(i, j int) bool {
+		a, b := s.Agents[order[i]], s.Agents[order[j]]
+		if a.Next != b.Next {
+			return a.Next
+		}
+		if a.Active != b.Active {
+			return a.Active
+		}
+		return a.State.Priority() < b.State.Priority()
+	})
+	selected := map[int]bool{}
+	pack := func(overflow bool) []string {
+		var rows []string
+		row := " "
+		for i, a := range s.Agents {
+			if !selected[i] {
+				continue
+			}
+			badge := agentBadge(a)
+			if ansiWidth(row) > 1 && ansiWidth(row)+ansiWidth(badge)+3 > width {
+				rows = append(rows, row)
+				row = " "
+			}
+			row += badge + "   "
+		}
+		if overflow {
+			more := fmt.Sprintf("+%d agents (%s)", len(s.Agents)-len(selected), s.Binding("Ctrl-Y"))
+			if ansiWidth(row)+len(more) > width && ansiWidth(row) > 1 {
+				rows = append(rows, row)
+				row = " "
+			}
+			row += more
+		}
+		return append(rows, row)
+	}
+	for _, i := range order {
+		selected[i] = true
+		if len(pack(len(selected) < len(s.Agents))) > 2 {
+			delete(selected, i)
+		}
+	}
+	return pack(len(selected) < len(s.Agents))
+}
+
+func agentOverview(s *review.State) string {
+	running, reviewing, waiting, errors := 0, 0, 0, 0
+	for _, a := range s.Agents {
+		if a.State.Execution == attention.Running {
+			running++
+		}
+		if a.State.Unreviewed() > 0 {
+			reviewing++
+		}
+		if a.State.Execution == attention.Waiting {
+			waiting++
+		}
+		if a.State.Execution == attention.Error {
+			errors++
+		}
+	}
+	text := fmt.Sprintf("Agents:%d  Run:%d  Review:%d  Wait:%d", len(s.Agents), running, reviewing, waiting)
+	if errors > 0 {
+		text += fmt.Sprintf("  Error:%d", errors)
+	}
+	return text
+}

--- a/internal/ui/attention_test.go
+++ b/internal/ui/attention_test.go
@@ -1,0 +1,48 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/nccapo/stvena/internal/attention"
+	"github.com/nccapo/stvena/internal/review"
+)
+
+func TestAgentIndicatorsAndOverview(t *testing.T) {
+	s := review.State{Agents: []review.AgentSummary{
+		{Label: "Claude 1", Active: true, State: attention.State{Execution: attention.Running}},
+		{Label: "Claude 2", State: attention.State{Execution: attention.Completed}},
+		{Label: "Codex 1", Next: true, State: attention.State{Execution: attention.Running, Files: map[string]attention.File{"a": {Ready: true}, "b": {Ready: true}}}},
+	}}
+	text := ansi.Strip(strings.Join(agentRows(&s, 140), "\n"))
+	for _, want := range []string{"[Claude 1 ● RUNNING]", "Claude 2 ✓ DONE", "→Codex 1 ! REVIEW 2f / RUN"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing %q in %s", want, text)
+		}
+	}
+	if got := agentOverview(&s); !strings.Contains(got, "Agents:3  Run:2  Review:1  Wait:0") {
+		t.Fatal(got)
+	}
+	before := NewLayoutOptions(140, 40, 58, false, &s)
+	s.Agents[2].State.Files = nil
+	s.Agents[0].State.Execution = attention.Idle
+	if after := NewLayoutOptions(140, 40, 58, false, &s); before != after {
+		t.Fatal("status change resized PTY")
+	}
+}
+func TestAttentionOverflowKeepsHighestPriorityVisible(t *testing.T) {
+	s := review.State{}
+	for i := range 30 {
+		s.Agents = append(s.Agents, review.AgentSummary{Label: "Claude", Active: i == 0})
+	}
+	s.Agents[29].Next = true
+	s.Agents[29].State.Execution = attention.Error
+	for _, width := range []int{40, 80, 140} {
+		rows := agentRows(&s, width)
+		text := ansi.Strip(strings.Join(rows, "\n"))
+		if len(rows) > 2 || !strings.Contains(text, "× ERROR") || !strings.Contains(text, "agents (") {
+			t.Fatalf("width %d: %s", width, text)
+		}
+	}
+}

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -32,6 +32,7 @@ type Layout struct {
 	DiffWidth, DiffHeight int
 	Vertical              bool
 	FooterY, FooterHeight int
+	AgentRows             int
 }
 
 func NewLayout(width, height int) Layout { return NewLayoutOptions(width, height, 58, false) }
@@ -41,9 +42,14 @@ func NewLayoutOptions(width, height, ratio int, fullscreen bool, state ...*revie
 	l := Layout{Width: width, Height: height, LeftY: 1}
 	l.FooterHeight = min(len(controlRows(width, false, state...)), max(0, height-2))
 	l.FooterY = height - l.FooterHeight
-	contentHeight := max(1, l.FooterY-1)
+	if len(state) > 0 && state[0] != nil && len(state[0].Agents) > 0 {
+		l.AgentRows = min(2, len(state[0].Agents), max(0, l.FooterY-3))
+	}
+	top := 1 + l.AgentRows
+	l.LeftY = top
+	contentHeight := max(1, l.FooterY-top)
 	if fullscreen {
-		l.DiffY = 1
+		l.DiffY = top
 		l.DiffWidth = width
 		l.DiffHeight = contentHeight
 		return l
@@ -52,7 +58,7 @@ func NewLayoutOptions(width, height, ratio int, fullscreen bool, state ...*revie
 		l.LeftWidth = max(40, width*min(75, max(25, ratio))/100)
 		l.LeftHeight = contentHeight
 		l.DiffX = l.LeftWidth + 1
-		l.DiffY = 1
+		l.DiffY = top
 		l.DiffWidth = max(1, width-l.DiffX)
 		l.DiffHeight = contentHeight
 		return l
@@ -80,6 +86,13 @@ func Render(w io.Writer, terminal *vt.Emulator, state *review.State, layout Layo
 		focus += " · " + safeText(state.AgentLabel)
 	}
 	header := headerBG + bold + " Stvena " + reset + headerBG + "  " + focus + "  · " + safeText(state.AgentStatus) + reset
+	if len(state.Agents) > 0 {
+		pane := "AGENT"
+		if diffFocused {
+			pane = "REVIEW"
+		}
+		header = headerBG + bold + " Stvena " + reset + " · " + pane + " · " + agentOverview(state)
+	}
 	if len(state.Attachments) > 0 {
 		header += cyan + fmt.Sprintf(" · Context: %d (B)", len(state.Attachments)) + reset
 	}
@@ -91,6 +104,12 @@ func Render(w io.Writer, terminal *vt.Emulator, state *review.State, layout Layo
 		header += reset
 	}
 	rows[0] = reviewRow(header, layout.Width)
+	for y, row := range agentRows(state, layout.Width) {
+		if y >= layout.AgentRows {
+			break
+		}
+		rows[y+1] = reviewRow(row, layout.Width)
+	}
 
 	for y := 0; y < layout.LeftHeight && layout.LeftY+y < layout.FooterY; y++ {
 		rows[layout.LeftY+y] = renderTerminalRow(terminal, y, layout.LeftWidth)
@@ -123,7 +142,11 @@ func Render(w io.Writer, terminal *vt.Emulator, state *review.State, layout Layo
 		if diffFocused {
 			target = "review"
 		}
-		rows[0] = reviewRow(headerBG+bold+" BOTTOM PANEL · Arrows: move · Enter: select · Esc: "+target, layout.Width)
+		text := " BOTTOM PANEL"
+		if len(state.Agents) > 0 {
+			text += " · " + agentOverview(state)
+		}
+		rows[0] = reviewRow(headerBG+bold+text+" · Arrows: move · Enter: select · Esc: "+target, layout.Width)
 		cursorVisible = false
 	}
 	footerStart := FooterStart(layout.Width, layout.FooterHeight, state)
@@ -257,7 +280,7 @@ type FooterControl struct{ Key, Action, Label string }
 var FooterControls = []FooterControl{
 	{"Ctrl-G", "focus", "Switch panes"}, {"Ctrl-]", "new-agent", "New agent"},
 	{"Ctrl-N", "next-agent", "Next agent"}, {"Ctrl-P", "previous-agent", "Previous agent"},
-	{"Ctrl-W", "close-agent", "Close agent"},
+	{"Ctrl-W", "close-agent", "Close agent"}, {"Ctrl-Y", "next-attention", "Next attention"},
 	{"1", "1", "Changes"}, {"2", "2", "Workspace"}, {"3", "3", "Files"},
 	{"B", "B", "Context"}, {"b", "b", "Paste to agent"}, {"T", "T", "Checks"},
 	{"K", "K", "Checkpoint"}, {"a", "a", "Actions"}, {"F", "F", "Expand"},


### PR DESCRIPTION
Background agents can finish or change files without a visible indication that they need review. This adds live per-terminal execution and review state, compact status badges and a global summary, and configurable Ctrl-Y navigation through the attention queue. Background events preserve focus; opening a terminal does not acknowledge its changes.

Review clears through the existing file or all-hunk acknowledgement workflow for the relevant captured version. Tests cover session isolation, stale pinned reviews, rapid lifecycle events, capture timing, renames, and the background-edit → next-attention → review flow at 80 and 140 columns. Attention navigation selects the relevant diff while preserving existing editor integration and pinned review work.

The README now documents Homebrew installation, upgrades, uninstalling, supported platforms, migration from the install script, and stable-versus-preview releases.

Detection limits: file attribution covers explicit Claude edit tools and Codex apply_patch hooks. Arbitrary shell/MCP writes remain in the combined diff without an inferred owner. Unsupported waiting/turn events are not inferred from terminal text; Codex hook support/trust is required and explicit Claude settings remain intact.

Validation in a clean checkout of this commit:

- Go formatting, installer shell syntax, and `go vet ./...`
- `go test -race ./...`
- `go build ./...`
- VS Code extension: `npm ci`, `npm test`, and `npm run package`
- `git diff --check`; merge with current `main` checked without conflicts
