### PR TITLE
feat: add live review workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ If Stvena saves you from the "open the IDE just for the diff" loop, consider
 ## Why Stvena?
 
 - **See the work as it happens.** Review changes since the agent started, or
-  inspect staged, unstaged, and new files across the workspace.
+  inspect branch, staged, unstaged, and new changes. A retained session timeline
+  lets you reopen the stable edit batches Stvena actually observed.
 - **Read beyond the diff.** Browse the project tree, open complete files, and
   switch between unified and side-by-side views with syntax highlighting.
 - **Give the agent precise context.** Select code with the mouse or keyboard,
@@ -38,8 +39,9 @@ If Stvena saves you from the "open the IDE just for the diff" loop, consider
   terminals running, switch between them, and review their combined changes in
   one workspace.
 - **Follow saved edits in your editor.** The experimental Stvena Live extension
-  lists each newly captured batch and opens the working source at its first
-  changed line while focus stays in the integrated terminal.
+  lists captured activity and mirrors Stvena's current review range in the real
+  source file—never a native IDE diff. Editor selections can open TUI review or
+  enter Stvena's context tray.
 - **Keep track of your review.** Pin a captured version, mark files and hunks
   reviewed, and see when a reviewed change has changed again.
 - **Check the code you are looking at.** Run a command in a temporary checkout
@@ -181,7 +183,7 @@ but direct selection paste is supported for Codex and Claude Code.
 | **Ctrl-Y** | Next attention: error, review, waiting, changed, running, done |
 | **Ctrl-W** | Close current agent terminal and stop its command |
 | **Ctrl-Q** | Quit Stvena and stop all agents |
-| **1 / 2 / 3** | Session changes / workspace changes / project files |
+| **1 / 2 / 3 / 4** | Session / workspace / project files / branch changes |
 | **Enter / f** | Open file / return to file browser |
 | **v** | Toggle diff and full-file view |
 | **Drag / V** | Select code with mouse / keyboard |
@@ -189,6 +191,7 @@ but direct selection paste is supported for Codex and Claude Code.
 | **P** | Pin the displayed version or resume live updates |
 | **K / Z** | Start Review checkpoint / finish and preview its draft |
 | **Space / N** | Mark file reviewed / next unreviewed file |
+| **I / L** | Toggle review inbox / open observed session timeline |
 | **t / T** | Run a check / inspect results |
 | **a / ?** | Actions menu / keyboard help |
 
@@ -296,12 +299,18 @@ not restored after restarting Stvena; saved review records continue to work.
 ## Follow reads and edits in VS Code
 
 The experimental [Stvena Live extension](https://marketplace.visualstudio.com/items?itemName=nccapo.stvena-live) follows
-captured edits in the editor while Stvena runs in its integrated terminal. It
-opens working source files at the changed line, lists the latest changed files,
-and lets you pause and resume following. Supported Codex and Claude tool hooks
+captured edits and the active Stvena review range while Stvena runs in its
+integrated terminal. It always opens ordinary working source files—Stvena's TUI
+remains the diff surface. Use **Stvena: Review This Line in Stvena** to move the
+TUI to the editor cursor, or **Stvena: Add Selection to Context** to collect the
+captured selection in Stvena's tray. Supported Codex and Claude tool hooks
 also report read locations. Blue read markers and amber edit markers show the
 relevant lines with an inline label; markers expire after 15 seconds. Codex
 requires its normal `/hooks` trust review before read reporting runs.
+
+The purple review marker and editor-to-TUI commands currently require source
+builds of both Stvena and the extension from this repository. The published
+0.2.x preview continues to provide read/edit following only.
 
 Install **Stvena Live** by **nccapo** from the VS Code Extensions view, or run:
 
@@ -337,8 +346,8 @@ Click **Stvena: Following** in the status bar to pause or resume navigation;
 If the view stays **Waiting**, check the binary version and workspace trust,
 and open **Stvena Live** in the Output panel for connection errors.
 
-The extension targets VS Code 1.85 or newer. It reads saved
-file captures from the repository's Git directory; it does not run commands,
+The extension targets VS Code 1.85 or newer. It exchanges small, validated local
+descriptors through the repository's Git directory; it does not run commands,
 write source, add telemetry, or expose a network service.
 
 Updates are snapshots sampled roughly every 700 ms plus capture and extension

--- a/docs/editor-integration.md
+++ b/docs/editor-integration.md
@@ -1,7 +1,8 @@
 # Editor integration
 
-Stvena's VS Code extension follows reported reads and consecutive captured workspace versions. It
-opens the working source with `showTextDocument`, selecting the changed line
+Stvena's VS Code extension follows reported reads, consecutive captured workspace
+versions, and the source range currently selected in TUI review. It opens the
+ordinary working source with `showTextDocument`, selecting the relevant line
 and preserving keyboard focus during automatic updates, as described in the
 [VS Code API](https://code.visualstudio.com/api/references/vscode-api#window.showTextDocument).
 Deleted files are not opened; automatic following skips unsaved buffers.
@@ -45,8 +46,10 @@ sequence. The bridge publishes even when the terminal review is pinned. A
 capture error preserves the last successful batch and reports an error until a
 successful capture. Descriptor-write failures also appear in the terminal.
 
-This is a latest-state protocol, without acknowledgements, replay, per-agent
-attribution, or an ordered history within each batch. Source retention follows
+This descriptor is a latest-state protocol, without acknowledgements, replay,
+per-agent attribution, or an ordered history within each batch. The retained TUI
+session timeline is separate and is not exposed as patch data here. Source
+retention follows
 Stvena's existing snapshot refs: do not treat old object IDs as a durable archive.
 One Stvena process per repository remains the supported model.
 
@@ -76,6 +79,37 @@ Markers clear after 15 seconds, on pause/disconnect, or while buffers are dirty.
 Saved edits retain workspace-wide attribution; an edit marker does not claim
 that a specific agent made the change. Only the latest followed location is marked.
 
+## Review bridge and editor requests
+
+Review state uses a separate source-only `stvena-review.json` descriptor in the
+resolved Git directory. It contains no patch or source text; Stvena remains the
+authoritative diff surface. The version 1 fields are:
+
+| Field | Meaning |
+| --- | --- |
+| `version`, `session`, `sequence`, `active`, `updatedAt`, `changedAt` | Versioned session identity, change counter, lifecycle, heartbeat, and last focus/count change |
+| `focus` | Optional captured `tree`, review `source`, repository-relative `path`, and inclusive one-based `line` / `endLine` |
+| `unreviewedFiles`, `unreviewedHunks` | Remaining review work in the live cumulative session view |
+| `newerBatches` | Observed timeline batches newer than the currently pinned batch |
+
+The extension renders the current focus as a persistent purple source marker and
+opens only the working file. Consumers must validate the tree object ID, path,
+ranges, counts, timestamps, and heartbeat exactly as they do for live edit state.
+The captured tree records provenance; the ordinary working file may have moved on.
+
+User-initiated editor actions atomically replace `stvena-request.json` with
+owner-only permissions. A version 1 request contains `version`, matching
+`session`, unique `id`, `action` (`review` or `context`), validated repository
+`path`, inclusive one-based `line` / `endLine`, and `updatedAt`. Stvena accepts a
+request once, only for its current session, and only within a one-minute freshness
+window. `review` navigates the TUI without opening an IDE diff. `context` loads
+the range from Stvena's immutable latest project capture rather than trusting
+editor text, then saves it in the context tray. Dirty editor buffers are rejected
+by the extension before either request is written.
+
+This is a local, last-request-wins control channel without acknowledgements. An
+extension should say that it sent a request, not claim that Stvena completed it.
+
 ## Verification
 
 Run `go test -race ./...`, `go vet ./...`, `go build ./...`, and `npm test` from
@@ -92,8 +126,8 @@ code /tmp/stvena-editor-project \
 ```
 
 The host smoke test writes only to that disposable workspace. It checks automatic
-source opening and line selection, reads without saved changes, read expiry,
-pause/resume, addition/deletion handling,
+source opening and line selection, reads without saved changes, TUI review focus,
+editor request descriptors, read expiry, pause/resume, addition/deletion handling,
 unsaved buffer preservation, and the absence of diff tabs. Use the editor's equivalent CLI to validate a VS Code
 fork. Passing the protocol tests alone does not establish editor compatibility.
 

--- a/docs/product-direction.md
+++ b/docs/product-direction.md
@@ -1,6 +1,7 @@
 # Stvena product direction
 
-Explored 8 September 2026. These are proposals, not shipped features. Research
+Explored 8 September 2026 and updated 11 September 2026. Later sections include
+implementation status as well as proposals. Research
 uses official documentation, not hands-on competitor benchmarks. The local
 README and implementation were checked to distinguish additions from existing
 functionality.
@@ -153,9 +154,9 @@ success criteria on their own.
 The opportunity is the quality of this combined terminal workflow. This research
 does not establish that any proposal is absent from all competing products.
 
-## Implementation update — 8 September 2026
+## Implementation update — 11 September 2026
 
-The first three builds now have working initial implementations:
+The first four builds now have working initial implementations:
 
 - **Project files:** a searchable list of all captured files, including unchanged
   files, with full-file viewing and existing mouse/keyboard selection. This first
@@ -170,7 +171,16 @@ The first three builds now have working initial implementations:
   locations; open tested source; collect failures with nearby captured code; and
   explicitly rerun checks. Raw logs remain available. Ambiguous/generated paths
   can be collected with a source-unavailable explanation instead of guessed code.
+- **Session timeline:** retain up to 100 stable tree transitions observed by the
+  700 ms capture loop, browse them chronologically, pin a batch, and count newer
+  observed batches. These are explicitly observations rather than agent-turn or
+  authorship claims. Named bookmarks, arbitrary checkpoint comparison, review
+  event history, and restore remain future work.
 
-The session timeline, symbol/reference navigation and task evidence checklist
-remain proposals. The README is the current guide to supported controls and
-limits.
+Review inbox filtering, a merge-base Branch changes source, semantic live cursor
+anchoring, and a bidirectional source-only VS Code review bridge were also added.
+The editor continues to open normal working files; Stvena remains the sole diff
+surface.
+
+Symbol/reference navigation and the task evidence checklist remain proposals.
+The README is the current guide to supported controls and limits.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -155,6 +155,12 @@ edits. The top file count counts unique paths; line totals sum the displayed
 scopes. Renames show both paths, and binary/conflicted/incomplete previews are
 explicitly labeled.
 
+**Project files (3)** browses every nonignored file in the latest captured tree,
+including unchanged files. **Branch changes (4)** compares the captured working
+tree with the merge base of `HEAD` and the locally configured/default
+`origin/main`, `main`, `origin/master`, or `master`. It includes committed and
+working changes and never fetches or switches branches.
+
 The code viewer provides:
 
 - Syntax colors in unified diffs and complete files, with old/new line numbers.
@@ -209,6 +215,13 @@ and conflicts cannot be marked reviewed.
 review, skipping reviewed versions and wrapping within the current filter.
 Mark a file with **Space**, then use **N** to continue. Files changed again by
 the agent need review again and return to this queue.
+
+**I** toggles Review inbox, which hides reviewed file versions and counts the
+remaining files, hunks, and items changed again. **L** opens the session timeline.
+Each entry is a stable tree transition observed by Stvena, not a claimed agent
+turn or author. Enter pins that batch for inspection; the header counts newer
+batches, and **P** returns to the live cumulative session diff. Up to 100 batches
+are retained per saved session.
 
 The top visible source line is the keyboard selection. **V** starts a range;
 move to extend it. Selection pins the version. **y** copies selected source text,
@@ -363,11 +376,12 @@ The table below lists defaults.
 | Enter / f / Backspace | Open file / return to browser |
 | v / s / w | Full file / side-by-side diff / wrap lines |
 | F / + / - | Fullscreen review / wider review / wider agent |
-| 1 / 2 / 3 / Tab | Session / Workspace / Project files / workspace scope |
+| 1 / 2 / 3 / 4 / Tab | Session / Workspace / Project files / Branch changes / workspace scope |
 | / | Filter paths in browser; search text in code |
 | m / M / : | Next / previous text match / go to source line |
 | n / p | Next / previous file |
 | N | Open the next unreviewed file in the current view |
+| I / L | Toggle Review inbox / open observed session timeline |
 | d/u, PageDown/PageUp | Move half a page |
 | g/G, Home/End | First / last file or source line |
 | [ / ] | Previous / next hunk or full-file change |

--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.2
+
+- Follow the source range currently selected in Stvena without opening a native
+  editor diff.
+- Send an editor line to TUI review or add a saved editor selection to Stvena's
+  captured context tray.
+- Show cumulative unreviewed-file counts in the status bar.
+
 ## 0.2.1
 
 - Add the Stvena icon to the extension listing.

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -83,6 +83,20 @@ Navigation pauses while the activity list and saved source continue updating.
 Click again to resume. **Stvena: Show Latest Activity** opens the latest read or changed file.
 Automatic following skips unsaved buffers so their content and cursor stay intact.
 
+The bidirectional review features below currently require source builds of both
+the extension and the accompanying Stvena binary. Published 0.2.x builds provide
+the read/edit following described above.
+
+When the TUI is inside a file, a purple review marker follows its current source
+line or selected range. It is persistent while that review location is active;
+Stvena still renders the diff, and the extension opens only the ordinary working
+file. From an editor context menu or the Command Palette:
+
+- **Stvena: Review This Line in Stvena** opens the corresponding captured change
+  in the TUI, falling back to the captured project file when it is unchanged.
+- **Stvena: Add Selection to Context** adds the matching immutable captured lines
+  to Stvena's saved context tray. Save the editor buffer first.
+
 ## Following reads
 
 Stvena adds a `PostToolUse` observer to standard `stvena codex` and `stvena claude`
@@ -160,12 +174,13 @@ and [Claude hooks](https://code.claude.com/docs/en/hooks) interfaces.
 
 ## Local data
 
-The extension reads a private `stvena-live.json` descriptor inside the worktree's
-Git directory and opens working source files. There is no listening
+The extension reads private `stvena-live.json` and `stvena-review.json`
+descriptors inside the worktree's Git directory and writes validated user actions
+atomically to `stvena-request.json`. It opens working source files. There is no listening
 network service, account, or telemetry. Stvena's tool observer stores only the
 latest read location in its private session cache and includes it in the bridge.
-The extension neither
-writes source files nor runs terminal commands on the agent's behalf.
+The extension neither writes source files nor runs terminal commands on the
+agent's behalf.
 
 For connection or preview errors, select **Stvena Live** in the Output panel.
 

--- a/extensions/vscode/media/review.svg
+++ b/extensions/vscode/media/review.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="#b180d7" d="M2 2h8v2H4v8h8V8h2v6H2z"/><path fill="#b180d7" d="m8 1 7 3.5L8 8 6 4.5z"/><circle cx="8" cy="4.5" r="1" fill="#1e1e1e"/></svg>

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stvena-live",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stvena-live",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "@vscode/vsce": "^3.9.2"

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "stvena-live",
   "displayName": "Stvena Live",
   "description": "Follow agent reads and edits with live source navigation and line highlights.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "icon": "media/icon.png",
   "publisher": "nccapo",
   "license": "MIT",
@@ -51,6 +51,14 @@
       {
         "command": "stvena.openChange",
         "title": "Stvena: Open Captured Edit"
+      },
+      {
+        "command": "stvena.reviewInStvena",
+        "title": "Stvena: Review This Line in Stvena"
+      },
+      {
+        "command": "stvena.addSelectionToContext",
+        "title": "Stvena: Add Selection to Context"
       }
     ],
     "views": {
@@ -80,6 +88,16 @@
           "group": "navigation"
         }
       ],
+      "editor/context": [
+        {
+          "command": "stvena.reviewInStvena",
+          "group": "stvena@1"
+        },
+        {
+          "command": "stvena.addSelectionToContext",
+          "group": "stvena@2"
+        }
+      ],
       "commandPalette": [
         {
           "command": "stvena.openChange",
@@ -104,6 +122,15 @@
           "dark": "#cca70020",
           "light": "#b8950018",
           "highContrast": "#cca70030"
+        }
+      },
+      {
+        "id": "stvena.reviewBackground",
+        "description": "Background of the source range currently selected in Stvena review.",
+        "defaults": {
+          "dark": "#b180d720",
+          "light": "#7c3aab18",
+          "highContrast": "#b180d730"
         }
       }
     ]

--- a/extensions/vscode/src/activity.js
+++ b/extensions/vscode/src/activity.js
@@ -15,51 +15,81 @@ function readRow(repo) {
 function editRows(repo) {
   return repo.state.files.map(file => ({ repo, file, kind: 'edit', at: repo.state.changedAt }));
 }
+function reviewRow(repo) {
+  const focus = repo.review?.focus;
+  if (!focus) return undefined;
+  return { repo, kind: 'review', at: repo.review.changedAt || repo.review.updatedAt,
+    id: String(repo.review.sequence), source: focus.source,
+    file: { path: focus.path, line: focus.line, ranges: [{ start: focus.line, end: focus.endLine }] } };
+}
 function label(row) {
   if (row.kind === 'read') {
     const range = row.file.ranges[0];
     return `${row.agent || 'Agent'} · Read ${range ? `lines ${range.start}–${range.end}` : 'file (range unavailable)'}`;
   }
+  if (row.kind === 'review') {
+    const range = row.file.ranges[0];
+    return `Review in Stvena · ${row.source} · ${range.start === range.end ? `line ${range.start}` : `lines ${range.start}–${range.end}`}`;
+  }
   return 'Changed · latest captured edit';
 }
 
-// Decorations are separate from editor selection, so the activity remains visible
-// with keyboard focus in the terminal. Only the currently followed location is marked.
+// Decorations are separate from editor selection, so activity remains visible
+// with keyboard focus in the terminal. A persistent review range can coexist
+// with the one transient read/edit location currently being followed.
 function createMarkers(vscode, context) {
   const types = {};
-  for (const [kind, color] of [['read', 'editorInfo.foreground'], ['edit', 'editorWarning.foreground']]) {
+  for (const [kind, color] of [['read', 'editorInfo.foreground'], ['edit', 'editorWarning.foreground'], ['review', 'charts.purple']]) {
     types[kind] = vscode.window.createTextEditorDecorationType({
       isWholeLine: true, rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
-      backgroundColor: new vscode.ThemeColor(kind === 'read' ? 'stvena.readBackground' : 'stvena.editBackground'),
+      backgroundColor: new vscode.ThemeColor(`stvena.${kind}Background`),
       borderWidth: '0 0 0 2px', borderStyle: 'solid', borderColor: new vscode.ThemeColor(color),
       overviewRulerColor: new vscode.ThemeColor(color), overviewRulerLane: vscode.OverviewRulerLane.Right,
       gutterIconPath: vscode.Uri.file(context.asAbsolutePath(`media/${kind}.svg`)), gutterIconSize: 'contain',
     });
     context.subscriptions.push(types[kind]);
   }
-  let current;
+  let current, reviews = [];
   function paint() {
     for (const editor of vscode.window.visibleTextEditors) {
       for (const type of Object.values(types)) editor.setDecorations(type, []);
-      if (!current || editor.document.isDirty || editor.document.uri.toString() !== current.uri || !fresh(current.row.at)) continue;
-      const row = current.row;
-      // An unknown read range gets a marker at its reported starting line only.
-      const ranges = row.file.ranges?.length ? row.file.ranges : [{ start: row.file.line, end: row.file.line }];
-      const options = ranges.map((range, index) => {
-        const start = Math.min(range.start - 1, editor.document.lineCount - 1);
-        const end = Math.min(range.end - 1, editor.document.lineCount - 1);
-        return { range: new vscode.Range(start, 0, end, editor.document.lineAt(end).text.length),
-          hoverMessage: label(row),
-          ...(index === 0 ? { renderOptions: { after: { contentText: `  ${label(row)}`, margin: '0 0 0 1em',
-            color: new vscode.ThemeColor(row.kind === 'read' ? 'editorInfo.foreground' : 'editorWarning.foreground') } } } : {}) };
-      });
-      editor.setDecorations(types[row.kind || 'edit'], options);
+      if (editor.document.isDirty) continue;
+      for (const entry of [...reviews, current].filter(Boolean)) {
+        if (editor.document.uri.toString() !== entry.uri ||
+            (entry.row.kind !== 'review' && !fresh(entry.row.at))) continue;
+        const row = entry.row;
+        // An unknown read range gets a marker at its reported starting line only.
+        const ranges = row.file.ranges?.length ? row.file.ranges : [{ start: row.file.line, end: row.file.line }];
+        const options = ranges.map((range, index) => {
+          const start = Math.min(range.start - 1, editor.document.lineCount - 1);
+          const end = Math.min(range.end - 1, editor.document.lineCount - 1);
+          return { range: new vscode.Range(start, 0, end, editor.document.lineAt(end).text.length),
+            hoverMessage: label(row),
+            ...(index === 0 ? { renderOptions: { after: { contentText: `  ${label(row)}`, margin: '0 0 0 1em',
+              color: new vscode.ThemeColor(row.kind === 'read' ? 'editorInfo.foreground' :
+                row.kind === 'review' ? 'charts.purple' : 'editorWarning.foreground') } } } : {}) };
+        });
+        editor.setDecorations(types[row.kind || 'edit'], options);
+      }
     }
   }
   return {
-    show(row, uri) { current = { row, uri: uri.toString() }; paint(); },
-    refresh(isLive) { if (current && !isLive(current.row)) current = undefined; paint(); },
-    clear() { current = undefined; paint(); },
+    show(row, uri) {
+      const entry = { row, uri: uri.toString() };
+      if (row.kind === 'review') {
+        reviews = reviews.filter(existing => row.repo?.root ? existing.row.repo?.root !== row.repo.root : existing.uri !== entry.uri);
+        reviews.push(entry);
+      }
+      else current = entry;
+      paint();
+    },
+    setReviews(entries) { reviews = entries.map(entry => ({ row: entry.row, uri: entry.uri.toString() })); paint(); },
+    refresh(isLive) {
+      if (current && !isLive(current.row)) current = undefined;
+      reviews = reviews.filter(entry => isLive(entry.row));
+      paint();
+    },
+    clear() { current = undefined; reviews = []; paint(); },
   };
 }
-module.exports = { fresh, readRow, editRows, label, createMarkers };
+module.exports = { fresh, readRow, editRows, reviewRow, label, createMarkers };

--- a/extensions/vscode/src/bridge.js
+++ b/extensions/vscode/src/bridge.js
@@ -3,6 +3,7 @@
 const { execFile } = require('node:child_process');
 const fs = require('node:fs/promises');
 const path = require('node:path');
+const { randomUUID } = require('node:crypto');
 const { promisify } = require('node:util');
 const exec = promisify(execFile);
 const oidPattern = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
@@ -17,7 +18,8 @@ async function git(root, ...args) {
 async function discover(folder) {
   const root = (await git(folder, 'rev-parse', '--show-toplevel')).toString().replace(/\n$/, '');
   const gitDir = (await git(root, 'rev-parse', '--absolute-git-dir')).toString().replace(/\n$/, '');
-  return { root, statePath: path.join(gitDir, 'stvena-live.json') };
+  return { root, statePath: path.join(gitDir, 'stvena-live.json'),
+    reviewPath: path.join(gitDir, 'stvena-review.json'), requestPath: path.join(gitDir, 'stvena-request.json') };
 }
 
 function validPath(value) {
@@ -65,12 +67,37 @@ function parseState(data) {
 }
 
 async function readState(repo) {
+  return readMetadata(repo.statePath, 8 * 1024 * 1024, parseState);
+}
+
+function parseReviewState(data) {
+  const state = JSON.parse(data);
+  if (state.version !== 1 || typeof state.session !== 'string' || !state.session ||
+      !Number.isSafeInteger(state.sequence) || state.sequence < 0 || typeof state.active !== 'boolean' ||
+      typeof state.updatedAt !== 'string' || !Number.isFinite(Date.parse(state.updatedAt)) ||
+      (state.changedAt !== undefined && !Number.isFinite(Date.parse(state.changedAt))) ||
+      !Number.isSafeInteger(state.unreviewedFiles) || state.unreviewedFiles < 0 ||
+      !Number.isSafeInteger(state.unreviewedHunks) || state.unreviewedHunks < 0 ||
+      !Number.isSafeInteger(state.newerBatches) || state.newerBatches < 0) {
+    throw new Error('Unsupported or invalid Stvena review state; update Stvena and the extension together.');
+  }
+  const focus = state.focus;
+  if (focus !== undefined && (!focus || !['session', 'workspace', 'project', 'branch'].includes(focus.source) ||
+      typeof focus.tree !== 'string' || !oidPattern.test(focus.tree) || /^0+$/.test(focus.tree) || !validPath(focus.path) ||
+      !Number.isSafeInteger(focus.line) || focus.line < 1 ||
+      !Number.isSafeInteger(focus.endLine) || focus.endLine < focus.line)) {
+    throw new Error('Invalid Stvena review focus.');
+  }
+  return state;
+}
+
+async function readMetadata(filePath, limit, parse) {
   try {
     // Reject oversized metadata before parsing it. Source stays in Git objects.
-    const file = await fs.open(repo.statePath, 'r');
+    const file = await fs.open(filePath, 'r');
     try {
-      if ((await file.stat()).size > 8 * 1024 * 1024) throw new Error('Stvena live state exceeds 8 MiB.');
-      return parseState(await file.readFile('utf8'));
+      if ((await file.stat()).size > limit) throw new Error('Stvena metadata exceeds its size limit.');
+      return parse(await file.readFile('utf8'));
     } finally {
       await file.close();
     }
@@ -80,8 +107,32 @@ async function readState(repo) {
   }
 }
 
+async function readReviewState(repo) {
+  return readMetadata(repo.reviewPath, 64 * 1024, parseReviewState);
+}
+
 function isLive(state, now = Date.now()) {
   return !!state && state.active && now - Date.parse(state.updatedAt) < 30000;
+}
+
+async function writeRequest(repo, request) {
+  if (!isLive(repo.review)) throw new Error('Stvena review is not active in this repository.');
+  if (!request || !['review', 'context'].includes(request.action) || !validPath(request.path) ||
+      !Number.isSafeInteger(request.line) || request.line < 1 ||
+      !Number.isSafeInteger(request.endLine) || request.endLine < request.line) {
+    throw new Error('Invalid Stvena editor request.');
+  }
+  const value = { version: 1, session: repo.review.session, id: randomUUID(), action: request.action,
+    path: request.path, line: request.line, endLine: request.endLine, updatedAt: new Date().toISOString() };
+  const temporary = `${repo.requestPath}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    await fs.writeFile(temporary, `${JSON.stringify(value)}\n`, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
+    await fs.rename(temporary, repo.requestPath);
+  } catch (error) {
+    await fs.rm(temporary, { force: true }).catch(() => {});
+    throw error;
+  }
+  return value;
 }
 
 async function readBlob(root, oid) {
@@ -92,4 +143,4 @@ async function readBlob(root, oid) {
   return data.toString('utf8');
 }
 
-module.exports = { discover, readState, parseState, isLive, readBlob };
+module.exports = { discover, readState, parseState, readReviewState, parseReviewState, isLive, writeRequest, readBlob };

--- a/extensions/vscode/src/extension.js
+++ b/extensions/vscode/src/extension.js
@@ -19,9 +19,9 @@ function activate(context) {
     getChildren: () => rows,
     getTreeItem: row => {
       const item = new vscode.TreeItem(row.file.path);
-      item.description = row.kind === 'read' ? activity.label(row) : `${row.file.status} +${row.file.added} −${row.file.deleted} · ${path.basename(row.repo.root)}`;
+      item.description = row.kind === 'edit' ? `${row.file.status} +${row.file.added} −${row.file.deleted} · ${path.basename(row.repo.root)}` : activity.label(row);
       item.tooltip = `${row.file.oldPath ? row.file.oldPath + ' → ' : ''}${row.file.path}\nLine ${row.file.line} · ${activity.label(row)}`;
-      item.iconPath = new vscode.ThemeIcon(row.kind === 'read' ? 'eye' : row.file.binary ? 'file-binary' : 'file-code');
+      item.iconPath = new vscode.ThemeIcon(row.kind === 'read' ? 'eye' : row.kind === 'review' ? 'inspect' : row.file.binary ? 'file-binary' : 'file-code');
       item.command = { command: 'stvena.openChange', title: 'Open edit', arguments: [row] };
       return item;
     },
@@ -37,24 +37,31 @@ function activate(context) {
   }
 
   function updateStatus() {
-    const live = repos.filter(repo => bridge.isLive(repo.state));
-    const failed = live.some(repo => repo.state.error) || errors.size > 0;
-    status.text = `$(pulse) Stvena: ${!following ? 'Paused' : failed ? 'Waiting for capture' : live.length ? 'Following' : 'Waiting'}`;
-    status.tooltip = `${latest && activity.fresh(latest.at) ? `${activity.label(latest)} · ${latest.file.path}\n` : ''}Click to pause/resume following. Run stvena in the project terminal. Open Stvena Live output for connection errors.`;
+    const liveEdits = repos.filter(repo => bridge.isLive(repo.state));
+    const liveReviews = repos.filter(repo => bridge.isLive(repo.review));
+    const live = new Set([...liveEdits, ...liveReviews]);
+    const unreviewed = liveReviews.reduce((sum, repo) => sum + repo.review.unreviewedFiles, 0);
+    const failed = liveEdits.some(repo => repo.state.error) || errors.size > 0;
+    const suffix = unreviewed ? ` · ${unreviewed} to review` : '';
+    status.text = `$(pulse) Stvena: ${!following ? 'Paused' : failed ? 'Waiting for capture' : live.size ? 'Following' : 'Waiting'}${suffix}`;
+    const latestVisible = latest && rows.some(row => row.repo.root === latest.repo.root && row.kind === latest.kind &&
+      row.file.path === latest.file.path && row.id === latest.id && row.at === latest.at) &&
+      (latest.kind === 'review' || activity.fresh(latest.at));
+    status.tooltip = `${latestVisible ? `${activity.label(latest)} · ${latest.file.path}\n` : ''}Click to pause/resume following. Run stvena in the project terminal. Open Stvena Live output for connection errors.`;
     tree.message = failed ? 'Capture unavailable. See Stvena Live output.' :
-      !live.length ? 'Waiting for stvena in this workspace.' :
+      !live.size ? 'Waiting for stvena in this workspace.' :
       !following ? 'Following paused. Select any captured edit to inspect it.' :
-      latest && activity.fresh(latest.at) ? `${activity.label(latest)} · ${latest.file.path}` :
-      'Following reads and edits · waiting for activity';
+      latestVisible ? `${activity.label(latest)} · ${latest.file.path}` :
+      'Following Stvena review, reads, and edits · waiting for activity';
   }
 
   async function show(row, automatic = false) {
     if (!row || disposed) return;
-    if (row.file.binary || row.file.truncated) {
+    if (row.kind !== 'review' && (row.file.binary || row.file.truncated)) {
       if (!automatic) await vscode.window.showInformationMessage('This captured edit has no complete text preview (binary or size limit).');
       return;
     }
-    if (/^0+$/.test(row.file.after)) {
+    if (row.kind !== 'review' && /^0+$/.test(row.file.after)) {
       if (!automatic) await vscode.window.showInformationMessage('This file was deleted; there is no working file to follow.');
       return;
     }
@@ -81,6 +88,35 @@ function activate(context) {
     }
   }
 
+  function activeEditorTarget() {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.uri.scheme !== 'file') throw new Error('Open a repository file first.');
+    if (editor.document.isDirty) throw new Error('Save the file before sending its captured range to Stvena.');
+    const repo = repos.find(candidate => {
+      const relative = path.relative(candidate.root, editor.document.uri.fsPath);
+      return relative && relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative) && bridge.isLive(candidate.review);
+    });
+    if (!repo) throw new Error('No active Stvena review owns this file.');
+    const relative = path.relative(repo.root, editor.document.uri.fsPath).split(path.sep).join('/');
+    const selection = editor.selection;
+    const line = selection.start.line + 1;
+    let endLine = selection.end.line + 1;
+    if (!selection.isEmpty && selection.end.character === 0 && endLine > line) endLine--;
+    return { repo, path: relative, line, endLine: Math.max(line, endLine) };
+  }
+
+  async function sendEditorRequest(action) {
+    try {
+      const target = activeEditorTarget();
+      await bridge.writeRequest(target.repo, { action, path: target.path, line: target.line, endLine: target.endLine });
+      void vscode.window.showInformationMessage(action === 'review' ?
+        `Sent ${target.path}:${target.line} to Stvena review.` :
+        `Sent ${target.path}:${target.line}–${target.endLine} to Stvena context.`);
+    } catch (error) {
+      void vscode.window.showErrorMessage(`Stvena: ${error.message}`);
+    }
+  }
+
   async function poll() {
     if (busy || disposed) return;
     busy = true;
@@ -104,39 +140,53 @@ function activate(context) {
       }
       let follow;
       for (const repo of repos) {
+        const reviewErrorKey = `${repo.root} review`;
         try {
           repo.state = await bridge.readState(repo);
           if (!repo.state?.error) errors.delete(repo.root);
-          if (!bridge.isLive(repo.state) || repo.state.error) {
-            if (repo.state?.error) report(repo.root, new Error(repo.state.error));
-            continue;
-          }
-          const read = activity.readRow(repo);
-          const key = `${repo.state.session}:${repo.state.sequence}`;
-          const previous = seen.get(repo.root);
-          const readID = repo.state.activity?.id;
-          if (previous?.edit !== key || (read && previous?.read !== readID)) {
-            const files = activity.editRows(repo);
-            const followable = files.filter(row => !row.file.binary && !row.file.truncated && !/^0+$/.test(row.file.after));
-            const edit = followable.find(row =>
-              displayed?.repo.root === repo.root && displayed?.file.path === row.file.path) ||
-              followable[0];
-            let candidate = previous?.edit !== key ? edit : undefined;
-            if (read && previous?.read !== readID && (!candidate || Date.parse(read.at) >= (Date.parse(candidate.at) || 0))) candidate = read;
-            if (candidate && (!follow || (Date.parse(candidate.at) || 0) >= (Date.parse(follow.at) || 0))) follow = candidate;
-          }
-          seen.set(repo.root, { edit: key, read: readID });
         } catch (error) {
           repo.state = undefined;
           report(repo.root, error);
         }
+        try {
+          repo.review = await bridge.readReviewState(repo);
+          errors.delete(reviewErrorKey);
+        } catch (error) {
+          repo.review = undefined;
+          report(reviewErrorKey, error);
+        }
+        const liveState = bridge.isLive(repo.state) && !repo.state.error;
+        const liveReview = bridge.isLive(repo.review);
+        if (repo.state?.error) report(repo.root, new Error(repo.state.error));
+        const read = liveState ? activity.readRow(repo) : undefined;
+        const key = liveState ? `${repo.state.session}:${repo.state.sequence}` : undefined;
+        const readID = liveState ? repo.state.activity?.id : undefined;
+        const review = liveReview ? activity.reviewRow(repo) : undefined;
+        const reviewKey = liveReview ? `${repo.review.session}:${repo.review.sequence}` : undefined;
+        const previous = seen.get(repo.root);
+        let candidate;
+        if (liveState && (previous?.edit !== key || (read && previous?.read !== readID))) {
+          const files = activity.editRows(repo);
+          const followable = files.filter(row => !row.file.binary && !row.file.truncated && !/^0+$/.test(row.file.after));
+          const edit = followable.find(row =>
+            displayed?.repo.root === repo.root && displayed?.file.path === row.file.path) || followable[0];
+          candidate = previous?.edit !== key ? edit : undefined;
+          if (read && previous?.read !== readID && (!candidate || Date.parse(read.at) >= (Date.parse(candidate.at) || 0))) candidate = read;
+        }
+        if (review && previous?.review !== reviewKey && (!candidate || Date.parse(review.at) >= (Date.parse(candidate.at) || 0))) candidate = review;
+        if (candidate && (!follow || Date.parse(candidate.at) >= (Date.parse(follow.at) || 0))) follow = candidate;
+        seen.set(repo.root, { edit: key, read: readID, review: reviewKey });
       }
       if (disposed) return;
-      rows = repos.flatMap(repo => bridge.isLive(repo.state) && !repo.state.error ?
-        [activity.readRow(repo), ...activity.editRows(repo)].filter(Boolean) : []);
+      rows = repos.flatMap(repo => [
+        ...(bridge.isLive(repo.review) ? [activity.reviewRow(repo)] : []),
+        ...(bridge.isLive(repo.state) && !repo.state.error ? [activity.readRow(repo), ...activity.editRows(repo)] : []),
+      ].filter(Boolean));
       if (follow) latest = follow;
       // Read expiry must clear the marker without jumping back to an old edit.
-      if (follow && !activity.fresh(follow.at) && follow.at) follow = undefined;
+      if (follow && follow.kind !== 'review' && !activity.fresh(follow.at) && follow.at) follow = undefined;
+      markers.setReviews(following ? rows.filter(row => row.kind === 'review').map(row => ({ row,
+        uri: vscode.Uri.file(path.join(row.repo.root, row.file.path)) })) : []);
       markers.refresh(row => rows.some(current => current.repo.root === row.repo.root &&
         current.kind === row.kind && current.file.path === row.file.path && current.at === row.at && current.id === row.id));
       changes.fire();
@@ -153,10 +203,12 @@ function activate(context) {
     vscode.workspace.onDidChangeTextDocument(() => markers.refresh(() => true)),
     vscode.workspace.onDidChangeWorkspaceFolders(() => { discoveryAt = 0; }),
     vscode.commands.registerCommand('stvena.openChange', row => show(row)),
+    vscode.commands.registerCommand('stvena.reviewInStvena', () => sendEditorRequest('review')),
+    vscode.commands.registerCommand('stvena.addSelectionToContext', () => sendEditorRequest('context')),
     vscode.commands.registerCommand('stvena.showLatest', async () => {
       if (latest && rows.some(row => row.repo.root === latest.repo.root &&
         row.kind === latest.kind && row.id === latest.id && row.at === latest.at &&
-        row.file.path === latest.file.path && row.file.after === latest.file.after)) await show(latest);
+        row.file.path === latest.file.path && (row.kind === 'review' || row.file.after === latest.file.after))) await show(latest);
       else if (rows.length) await show(rows[0]);
       else await vscode.window.showInformationMessage('Run stvena in this workspace and wait for a read or captured edit.');
     }),

--- a/extensions/vscode/test/activity.test.js
+++ b/extensions/vscode/test/activity.test.js
@@ -1,7 +1,7 @@
 'use strict';
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { fresh, readRow, label, createMarkers } = require('../src/activity');
+const { fresh, readRow, reviewRow, label, createMarkers } = require('../src/activity');
 const { parseState } = require('../src/bridge');
 
 test('read activity validates paths, ranges, session and freshness', () => {
@@ -19,6 +19,15 @@ test('read activity validates paths, ranges, session and freshness', () => {
   }
   state.activity.updatedAt = new Date(Date.now() - 16000).toISOString();
   assert.equal(readRow({ state }), undefined);
+});
+
+test('review focus becomes a persistent source marker', () => {
+  const repo = { review: { sequence: 5, updatedAt: new Date().toISOString(),
+    focus: { source: 'branch', path: 'a.go', line: 3, endLine: 6 } } };
+  const row = reviewRow(repo);
+  assert.equal(row.kind, 'review');
+  assert.equal(row.file.ranges[0].end, 6);
+  assert.match(label(row), /Review in Stvena · branch · lines 3–6/);
 });
 
 test('read/edit markers cover reported ranges, clamp EOF, and clear on dirty, expiry and disconnect', () => {
@@ -49,4 +58,11 @@ test('read/edit markers cover reported ranges, clamp EOF, and clear on dirty, ex
   assert.deepEqual(paints.get(1), []);
   markers.show({ ...row, at: new Date(Date.now() - 16000).toISOString() }, editor.document.uri);
   assert.deepEqual(paints.get(0), []);
+  markers.show({ ...row, kind: 'review', at: new Date(Date.now() - 60000).toISOString() }, editor.document.uri);
+  assert.equal(paints.get(2).length, 1);
+  markers.show(row, editor.document.uri);
+  assert.equal(paints.get(0).length, 1);
+  assert.equal(paints.get(2).length, 1);
+  markers.setReviews([]);
+  assert.deepEqual(paints.get(2), []);
 });

--- a/extensions/vscode/test/bridge.test.js
+++ b/extensions/vscode/test/bridge.test.js
@@ -6,7 +6,7 @@ const fs = require('node:fs/promises');
 const os = require('node:os');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
-const { discover, parseState, readState, isLive, readBlob } = require('../src/bridge');
+const { discover, parseState, readState, parseReviewState, readReviewState, isLive, writeRequest, readBlob } = require('../src/bridge');
 
 const state = () => ({ version: 1, session: 'test-session', sequence: 1, active: true,
   updatedAt: new Date().toISOString(), files: [{ path: 'nested/file.txt', status: 'M',
@@ -28,6 +28,19 @@ test('state validation and heartbeat expiry', () => {
   }
 });
 
+test('review state validation', () => {
+  const now = new Date().toISOString();
+  const value = { version: 1, session: 'review-session', sequence: 3, active: true,
+    updatedAt: now, changedAt: now, unreviewedFiles: 2, unreviewedHunks: 4, newerBatches: 1,
+    focus: { tree: '1'.repeat(40), source: 'session', path: 'nested/file.txt', line: 4, endLine: 7 } };
+  assert.deepEqual(parseReviewState(JSON.stringify(value)), value);
+  for (const change of [{ unreviewedFiles: -1 }, { newerBatches: 1.5 }, { changedAt: 'bad' },
+    { focus: { ...value.focus, path: '../outside' } }, { focus: { ...value.focus, endLine: 3 } },
+    { focus: { ...value.focus, source: 'unknown' } }, { focus: { ...value.focus, tree: '0'.repeat(40) } }]) {
+    assert.throws(() => parseReviewState(JSON.stringify({ ...value, ...change })));
+  }
+});
+
 test('discovers nested folders and worktrees; reads exact immutable blobs', async t => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'stvena-extension-'));
   t.after(() => fs.rm(root, { recursive: true, force: true }));
@@ -43,6 +56,7 @@ test('discovers nested folders and worktrees; reads exact immutable blobs', asyn
   const repo = await discover(path.join(root, 'nested'));
   assert.equal(await fs.realpath(repo.root), await fs.realpath(root));
   assert.equal(await readState(repo), undefined);
+  assert.equal(await readReviewState(repo), undefined);
   const value = state();
   value.files[0].before = oid;
   await fs.writeFile(repo.statePath, JSON.stringify(value));
@@ -58,4 +72,21 @@ test('discovers nested folders and worktrees; reads exact immutable blobs', asyn
   const worktree = await discover(path.join(root, 'worktree'));
   assert.notEqual(worktree.statePath, repo.statePath);
   assert.equal(await readState(worktree), undefined);
+});
+
+test('writes session-bound editor requests atomically', async t => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'stvena-request-'));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  execFileSync('git', ['-C', root, 'init', '-q']);
+  const repo = await discover(root);
+  repo.review = { version: 1, session: 'active-session', sequence: 0, active: true,
+    updatedAt: new Date().toISOString(), unreviewedFiles: 0, unreviewedHunks: 0, newerBatches: 0 };
+  const written = await writeRequest(repo, { action: 'context', path: 'file.go', line: 2, endLine: 5 });
+  const stored = JSON.parse(await fs.readFile(repo.requestPath, 'utf8'));
+  assert.deepEqual(stored, written);
+  assert.equal(stored.session, 'active-session');
+  assert.ok(stored.id);
+  await assert.rejects(writeRequest(repo, { action: 'context', path: '../outside', line: 1, endLine: 1 }));
+  repo.review.active = false;
+  await assert.rejects(writeRequest(repo, { action: 'review', path: 'file.go', line: 1, endLine: 1 }), /not active/);
 });

--- a/extensions/vscode/test/host.js
+++ b/extensions/vscode/test/host.js
@@ -25,6 +25,13 @@ async function run() {
     await fs.writeFile(repo.statePath + '.tmp', JSON.stringify(value));
     await fs.rename(repo.statePath + '.tmp', repo.statePath);
   }
+  async function writeReview(focus) {
+    const review = { version: 1, session: value.session, sequence: ++sequence, active: true,
+      updatedAt: new Date().toISOString(), changedAt: new Date().toISOString(), focus,
+      unreviewedFiles: 1, unreviewedHunks: 1, newerBatches: 0 };
+    await fs.writeFile(repo.reviewPath + '.tmp', JSON.stringify(review));
+    await fs.rename(repo.reviewPath + '.tmp', repo.reviewPath);
+  }
   async function publish(before, after, file = 'example.txt') {
     const target = path.join(root, file);
     if (/^0+$/.test(after)) await fs.rm(target, { force: true });
@@ -38,7 +45,7 @@ async function run() {
   async function waitFor(predicate, message) {
     const deadline = Date.now() + 12000;
     while (Date.now() < deadline) {
-      if (predicate()) return;
+      if (await predicate()) return;
       await new Promise(resolve => setTimeout(resolve, 100));
     }
     throw new Error(message);
@@ -106,9 +113,31 @@ async function run() {
     await new Promise(resolve => setTimeout(resolve, 1800));
     assert.equal(visible('reading.txt').selection.active.line, 4, 'Read expiry navigated to an old edit');
     noDiffs();
-    console.log('STVENA_HOST_TESTS_PASSED: edits, reads, ranges, pause/resume, expiry, unsaved buffer, no diffs');
+    // TUI review follows the ordinary source file and editor selections travel
+    // back through the local request descriptor, never through a native diff.
+    await writeReview({ tree: '1'.repeat(40), source: 'session', path: 'reading.txt', line: 3, endLine: 4 });
+    await waitFor(() => visible('reading.txt')?.selection.active.line === 2, 'TUI review focus did not follow source');
+    const reviewEditor = visible('reading.txt');
+    reviewEditor.selection = new vscode.Selection(2, 0, 3, 1);
+    await vscode.commands.executeCommand('stvena.addSelectionToContext');
+    await waitFor(() => fs.access(repo.requestPath).then(() => true, () => false), 'Context request was not written');
+    let request = JSON.parse(await fs.readFile(repo.requestPath, 'utf8'));
+    assert.equal(request.action, 'context');
+    assert.equal(request.path, 'reading.txt');
+    assert.equal(request.line, 3);
+    assert.equal(request.endLine, 4);
+    const contextID = request.id;
+    await vscode.commands.executeCommand('stvena.reviewInStvena');
+    await waitFor(async () => JSON.parse(await fs.readFile(repo.requestPath, 'utf8')).id !== contextID,
+      'Review request did not replace the context request');
+    request = JSON.parse(await fs.readFile(repo.requestPath, 'utf8'));
+    assert.equal(request.action, 'review');
+    noDiffs();
+    console.log('STVENA_HOST_TESTS_PASSED: edits, reads, TUI review, editor requests, ranges, pause/resume, expiry, unsaved buffer, no diffs');
   } finally {
     await fs.rm(repo.statePath, { force: true });
+    await fs.rm(repo.reviewPath, { force: true });
+    await fs.rm(repo.requestPath, { force: true });
   }
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -37,7 +37,10 @@ type outputEvent struct {
 	agent *agentTerminal
 	data  []byte
 }
-type diffEvent struct{ snapshot, session, project diffview.Snapshot }
+type diffEvent struct {
+	snapshot, session, project, branch diffview.Snapshot
+	batches                            []session.Batch
+}
 type operationEvent struct {
 	message string
 	err     error
@@ -61,6 +64,7 @@ type contentEvent struct {
 	key     string
 	content diffview.Content
 }
+type editorRequestEvent struct{ request editor.Request }
 
 // Run starts the requested agent command. With no arguments it runs Codex.
 func Run(args []string) error {
@@ -148,11 +152,19 @@ func Run(args []string) error {
 	if savedSession != nil {
 		defer savedSession.Close()
 	}
+	var editorReview *editor.ReviewPublisher
+	var editorReviewErr error
+	if savedSession != nil {
+		editorReview, editorReviewErr = editor.OpenReview(savedSession)
+		if editorReview != nil {
+			defer editorReview.Close()
+		}
+	}
 	events := make(chan any, 32)
 	stop := make(chan struct{})
 	stopEvents := sync.OnceFunc(func() { close(stop) })
 	defer stopEvents()
-	state := screenState{layout: layout, session: savedSession, root: root, exited: standalone, ratio: 58, agentInput: io.Discard}
+	state := screenState{layout: layout, session: savedSession, root: root, exited: standalone, ratio: 58, agentInput: io.Discard, editorReview: editorReview}
 	defer state.closeAgents()
 	if !standalone {
 		state.launchCommand = append([]string(nil), args...)
@@ -255,6 +267,9 @@ func Run(args []string) error {
 	if sessionErr != nil {
 		state.review.Notice = "Session capture unavailable: " + sessionErr.Error()
 	}
+	if editorReviewErr != nil {
+		state.review.Notice = "Editor review bridge unavailable: " + editorReviewErr.Error()
+	}
 	if standalone {
 		state.diffFocused = true
 		state.fullscreen = true
@@ -318,6 +333,12 @@ func Run(args []string) error {
 				state.workspace.Label = "Workspace"
 				state.sessionView = value.session
 				state.projectView = value.project
+				state.branchView = value.branch
+				entries := make([]review.TimelineEntry, len(value.batches))
+				for i, batch := range value.batches {
+					entries[i] = review.TimelineEntry{ID: batch.ID, Before: batch.Before, After: batch.After, ObservedAt: batch.ObservedAt, FileCount: batch.FileCount, Added: batch.Added, Deleted: batch.Deleted}
+				}
+				state.review.SetTimeline(entries)
 				state.review.LiveTree = value.project.Tree
 				if state.review.LiveTree == "" {
 					state.review.LiveTree = value.snapshot.Tree
@@ -338,6 +359,10 @@ func Run(args []string) error {
 					state.clampScroll()
 					dirty = true
 				}
+			case editorRequestEvent:
+				state.applyEditorRequest(value.request)
+				state.queueContent(contentRequests)
+				dirty = true
 			case inputEvent:
 				state.handleInput(value.data, state.agentInput)
 				if state.dispatch(ctx, events, stop) {
@@ -397,6 +422,9 @@ func Run(args []string) error {
 
 			}
 		case <-renderTicker.C:
+			if state.publishEditorReview() {
+				dirty = true
+			}
 			for _, a := range state.agents {
 				if a.attention.Quiet(time.Now()) {
 					dirty = true
@@ -447,39 +475,41 @@ func Run(args []string) error {
 }
 
 type screenState struct {
-	agents                              []*agentTerminal
-	activeAgentIndex                    int
-	attentionPrevious                   *agentTerminal
-	agentSerial                         map[string]int
-	startAgent                          func([]string, ui.Layout) (*agentTerminal, error)
-	launchCommand                       []string
-	agentPicker                         *ui.AgentPicker
-	layout                              ui.Layout
-	review                              review.State
-	diffFocused                         bool
-	keyboardPending                     []byte
-	keyboardPasting                     bool
-	pending                             []byte
-	lastInput                           time.Time
-	contentID                           int
-	problemID                           int
-	contentStamp                        string
-	root                                string
-	session                             *session.Session
-	workspace, sessionView, projectView diffview.Snapshot
-	fullscreen, exited, busy            bool
-	ratio                               int
-	pendingStage                        *diffview.File
-	pendingHunk                         int
-	workers                             sync.WaitGroup
-	agentName                           string
-	agentInput                          io.Writer
-	bracketedPaste, pastePending        bool
-	pasteInput                          []byte
-	terminalPasting                     bool
-	terminalPasteToAgent                bool
-	terminalPasteMarker                 int
-	mouseDragging                       bool
+	agents                                          []*agentTerminal
+	activeAgentIndex                                int
+	attentionPrevious                               *agentTerminal
+	agentSerial                                     map[string]int
+	startAgent                                      func([]string, ui.Layout) (*agentTerminal, error)
+	launchCommand                                   []string
+	agentPicker                                     *ui.AgentPicker
+	layout                                          ui.Layout
+	review                                          review.State
+	diffFocused                                     bool
+	keyboardPending                                 []byte
+	keyboardPasting                                 bool
+	pending                                         []byte
+	lastInput                                       time.Time
+	contentID                                       int
+	problemID                                       int
+	contentStamp                                    string
+	root                                            string
+	session                                         *session.Session
+	workspace, sessionView, projectView, branchView diffview.Snapshot
+	fullscreen, exited, busy                        bool
+	ratio                                           int
+	pendingStage                                    *diffview.File
+	pendingHunk                                     int
+	workers                                         sync.WaitGroup
+	agentName                                       string
+	agentInput                                      io.Writer
+	bracketedPaste, pastePending                    bool
+	pasteInput                                      []byte
+	terminalPasting                                 bool
+	terminalPasteToAgent                            bool
+	terminalPasteMarker                             int
+	mouseDragging                                   bool
+	editorReview                                    *editor.ReviewPublisher
+	editorReviewReported                            bool
 }
 
 func (s *screenState) visibleLines() int {

--- a/internal/app/editor.go
+++ b/internal/app/editor.go
@@ -1,0 +1,114 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/nccapo/stvena/internal/diffview"
+	"github.com/nccapo/stvena/internal/editor"
+)
+
+func (s *screenState) publishEditorReview() bool {
+	if s.editorReview == nil {
+		return false
+	}
+	// Keep the previous focus while a replacement captured blob is loading;
+	// publishing an intermediate nil would make the IDE marker flicker.
+	if s.review.FullFile && s.review.ContentLoading {
+		return false
+	}
+	var focus *editor.ReviewFocus
+	if path, start, end, ok := s.review.WorkingRange(); ok && s.review.Snapshot.Tree != "" {
+		focus = &editor.ReviewFocus{Tree: s.review.Snapshot.Tree, Source: s.review.Source, Path: path, Line: start, EndLine: end}
+	}
+	files, hunks := s.review.ReviewCounts(s.sessionView)
+	err := s.editorReview.Publish(focus, files, hunks, s.review.NewerBatches)
+	if err != nil && !s.editorReviewReported {
+		s.review.Notice = "Editor review bridge unavailable: " + err.Error()
+		s.editorReviewReported = true
+		return true
+	}
+	s.editorReviewReported = err != nil
+	return false
+}
+
+func (s *screenState) applyEditorRequest(request editor.Request) {
+	if request.Action == "context" {
+		if err := s.review.AddCapturedRange(s.projectView, request.Path, request.Line, request.EndLine); err != nil {
+			s.review.Notice = "Editor context: " + err.Error()
+			return
+		}
+		s.review.Request = ""
+		if err := s.review.Save(); err != nil {
+			s.review.Notice = err.Error()
+			return
+		}
+		s.review.Notice = fmt.Sprintf("Collected %s:%d–%d from editor · B: context tray", request.Path, request.Line, request.EndLine)
+		return
+	}
+
+	if s.review.Checkpoint != nil {
+		if !snapshotHasPath(s.review.Snapshot, request.Path) {
+			s.review.Notice = "Checkpoint stays pinned; that editor file is outside its captured changes"
+			return
+		}
+		s.review.Pinned = false
+		s.review.ClearSelection()
+		s.openEditorRange(s.review.Snapshot, s.review.Source, request.Path, request.Line, s.review.FullFile)
+		s.review.Pinned = true
+		return
+	}
+	for _, candidate := range []struct {
+		snapshot diffview.Snapshot
+		source   string
+		full     bool
+	}{
+		{s.sessionView, "session", false},
+		{s.workspace, "workspace", false},
+		{s.projectView, "project", true},
+	} {
+		if snapshotHasPath(candidate.snapshot, request.Path) {
+			s.review.Pinned = false
+			s.review.ClearSelection()
+			s.openEditorRange(candidate.snapshot, candidate.source, request.Path, request.Line, candidate.full)
+			return
+		}
+	}
+	s.review.Notice = request.Path + " is not in the latest captured project"
+}
+
+func snapshotHasPath(snapshot diffview.Snapshot, path string) bool {
+	for _, file := range snapshot.Files {
+		if file.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *screenState) openEditorRange(snapshot diffview.Snapshot, source, path string, line int, full bool) {
+	s.review.Source = source
+	s.review.Inbox = false
+	s.review.Scope = 0
+	s.review.Query = ""
+	s.review.Panel = ""
+	s.review.FullFile = full
+	s.review.TargetLine = 0
+	s.review.Update(snapshot)
+	for visible, index := range s.review.Indices {
+		if snapshot.Files[index].Path == path {
+			s.review.Selected = visible
+			break
+		}
+	}
+	s.review.Browser = false
+	s.review.PatchFocused = true
+	s.review.Scroll = 0
+	if full {
+		s.review.TargetLine = line
+	} else {
+		s.review.GoToLine(line)
+	}
+	s.diffFocused = true
+	s.review.FooterFocused = false
+	s.review.Notice = fmt.Sprintf("Reviewing %s:%d from editor", path, line)
+}

--- a/internal/app/editor_test.go
+++ b/internal/app/editor_test.go
@@ -1,0 +1,42 @@
+package app
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nccapo/stvena/internal/diffview"
+	"github.com/nccapo/stvena/internal/editor"
+)
+
+func TestEditorRequestsOpenStvenaAndCollectCapturedContext(t *testing.T) {
+	root, baseline := workflowProject(t)
+	if err := os.WriteFile(filepath.Join(root, "a.go"), []byte("package main\nfunc changed() {}\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("git", "-C", root, "add", ".").CombinedOutput(); err != nil {
+		t.Fatalf("git add: %s: %v", out, err)
+	}
+	out, err := exec.Command("git", "-C", root, "write-tree").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tree := strings.TrimSpace(string(out))
+	s := screenState{root: root}
+	s.sessionView = diffview.CompareTrees(root, baseline, tree)
+	s.workspace = diffview.Collect(root)
+	s.projectView = diffview.Project(root, tree)
+	if err := s.review.Load(root); err != nil {
+		t.Fatal(err)
+	}
+	s.applyEditorRequest(editor.Request{Action: "review", Path: "a.go", Line: 2, EndLine: 2})
+	if s.review.Source != "session" || s.review.Current() == nil || s.review.Current().Path != "a.go" || s.review.Browser || !s.diffFocused {
+		t.Fatalf("editor review did not open the TUI patch: %+v", s.review)
+	}
+	s.applyEditorRequest(editor.Request{Action: "context", Path: "b.go", Line: 2, EndLine: 2})
+	if len(s.review.Attachments) != 1 || !strings.Contains(s.review.Attachments[0].Message, "func beta()") {
+		t.Fatalf("editor context did not use captured project source: %+v", s.review.Attachments)
+	}
+}

--- a/internal/app/live_changes_test.go
+++ b/internal/app/live_changes_test.go
@@ -72,6 +72,9 @@ func TestChangesRefreshFromExternalProcess(t *testing.T) {
 			return strings.Contains(strings.Join(found["a.go"].Lines, "\n"), want) &&
 				found["b.go"].Status == "D" && found[added].Status == "A" && e.snapshot.Err == nil
 		})
+		if len(e.batches) == 0 {
+			t.Fatal("observed change was not added to the session timeline")
+		}
 		if e.project.Tree != e.session.Tree || e.snapshot.Tree != e.session.Tree {
 			t.Fatal("views did not refresh to the same captured files")
 		}
@@ -94,6 +97,48 @@ func TestChangesRefreshFromExternalProcess(t *testing.T) {
 		}
 		if !found {
 			t.Fatalf("editor bridge missed edited line: %+v", live.Files)
+		}
+	}
+}
+
+func TestWatcherDeliversFreshEditorRequest(t *testing.T) {
+	root, _ := workflowProject(t)
+	saved, err := session.Open(root, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer saved.Close()
+	events, stop, done := make(chan any, 8), make(chan struct{}), make(chan struct{})
+	go func() {
+		defer close(done)
+		watchSnapshots(root, nil, saved, events, stop)
+	}()
+	defer func() { close(stop); <-done }()
+	select {
+	case event := <-events:
+		if _, ok := event.(diffEvent); !ok {
+			t.Fatalf("first watcher event was %T", event)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("initial watcher refresh stalled")
+	}
+	request := editor.Request{Version: 1, Session: saved.ID, ID: "editor-request", Action: "review", Path: "a.go", Line: 2, EndLine: 2, UpdatedAt: time.Now().UTC()}
+	if err := session.AtomicJSON(filepath.Join(root, ".git", "stvena-request.json"), request); err != nil {
+		t.Fatal(err)
+	}
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case event := <-events:
+			if delivered, ok := event.(editorRequestEvent); ok {
+				if delivered.request.ID != request.ID || delivered.request.Path != "a.go" {
+					t.Fatalf("wrong editor request: %+v", delivered.request)
+				}
+				return
+			}
+		case <-timer.C:
+			t.Fatal("fresh editor request was not delivered")
 		}
 	}
 }

--- a/internal/app/mouse.go
+++ b/internal/app/mouse.go
@@ -109,17 +109,22 @@ func (s *screenState) mouse(sequence string) {
 			s.review.Key(key, s.visibleLines())
 			return
 		}
-		if s.review.Panel == "Context" || s.review.Panel == "Problems" {
+		if s.review.Panel == "Context" || s.review.Panel == "Problems" || s.review.Panel == "Timeline" {
 			index, total := s.review.TrayIndex, len(s.review.Attachments)
 			if s.review.Panel == "Problems" {
 				index, total = s.review.ProblemIndex, len(s.review.Problems)
+			} else if s.review.Panel == "Timeline" {
+				index, total = s.review.TimelineIndex, len(s.review.Timeline)
 			}
 			start, count := ui.PanelListWindow(index, total, s.layout.DiffHeight)
 			if row >= 1 && row <= count {
 				if s.review.Panel == "Context" {
 					s.review.TrayIndex = start + row - 1
-				} else {
+				} else if s.review.Panel == "Problems" {
 					s.review.ProblemIndex = start + row - 1
+					s.review.Key("enter", s.visibleLines())
+				} else {
+					s.review.TimelineIndex = start + row - 1
 					s.review.Key("enter", s.visibleLines())
 				}
 			}

--- a/internal/app/workspace.go
+++ b/internal/app/workspace.go
@@ -29,7 +29,12 @@ func watchSnapshots(root string, rootErr error, saved *session.Session, events c
 		defer publisher.Close()
 	}
 	bridgeReported := false
-	var project diffview.Snapshot
+	requests, requestErr := editor.OpenRequests(saved)
+	requestReported := false
+	timelineReported := false
+	var project, branch diffview.Snapshot
+	branchKey := ""
+	observedTree := saved.LastTree
 	refresh := func() {
 		capturedAt := time.Now()
 		tree, err := saved.Capture()
@@ -51,6 +56,28 @@ func watchSnapshots(root string, rootErr error, saved *session.Session, events c
 		if err == nil && (project.Tree != tree || project.Err != nil) {
 			project = diffview.Project(root, tree)
 		}
+		head := diffview.BranchHead(root)
+		if err == nil && (branchKey != tree+"\x00"+head || branch.Err != nil) {
+			branch = diffview.BranchChanges(root, tree)
+			branchKey = tree + "\x00" + head
+		}
+		if err == nil && observedTree != "" && observedTree != tree {
+			delta := diffview.CompareTrees(root, observedTree, tree)
+			if delta.Err == nil {
+				batchErr := saved.RecordBatch(observedTree, tree, capturedAt, delta.FileCount, delta.Added, delta.Deleted)
+				if batchErr == nil {
+					observedTree = tree
+				}
+				if batchErr != nil && !timelineReported {
+					select {
+					case events <- operationEvent{message: "Session timeline unavailable", err: batchErr}:
+					case <-stop:
+						return
+					}
+				}
+				timelineReported = batchErr != nil
+			}
+		}
 		// Attention events must compare against when the tree was captured, not
 		// when the subsequent Git diff finished processing an older tree.
 		view.UpdatedAt = capturedAt
@@ -70,8 +97,34 @@ func watchSnapshots(root string, rootErr error, saved *session.Session, events c
 		}
 		bridgeReported = bridgeErr != nil
 		select {
-		case events <- diffEvent{snapshot: workspace, session: view, project: deliveredProject}:
+		case events <- diffEvent{snapshot: workspace, session: view, project: deliveredProject, branch: branch, batches: append([]session.Batch(nil), saved.Batches...)}:
 		case <-stop:
+			return
+		}
+		if requests != nil {
+			request, err := requests.Poll()
+			if err != nil && !requestReported {
+				select {
+				case events <- operationEvent{message: "Editor request unavailable", err: err}:
+				case <-stop:
+					return
+				}
+			}
+			requestReported = err != nil
+			if request != nil {
+				select {
+				case events <- editorRequestEvent{request: *request}:
+				case <-stop:
+					return
+				}
+			}
+		} else if requestErr != nil && !requestReported {
+			select {
+			case events <- operationEvent{message: "Editor requests unavailable", err: requestErr}:
+			case <-stop:
+				return
+			}
+			requestReported = true
 		}
 	}
 	refresh()
@@ -94,6 +147,8 @@ func (s *screenState) updateSource() {
 			project.Err = fmt.Errorf("Waiting for project capture; if Git was initialized after launch, restart stvena")
 		}
 		s.review.Update(project)
+	} else if s.review.Source == "branch" {
+		s.review.Update(s.branchView)
 	} else if s.review.Source == "session" && s.session != nil {
 		s.review.Update(s.sessionView)
 	} else {
@@ -192,7 +247,7 @@ func (s *screenState) dispatch(ctx context.Context, events chan<- any, stop <-ch
 			s.ratio = min(75, s.ratio+5)
 		}
 		s.relayout(s.layout.Width, s.layout.Height)
-	case "1", "2", "3":
+	case "1", "2", "3", "4":
 		if s.review.Checkpoint != nil {
 			s.review.Notice = "Checkpoint stays pinned · Z: finish · P: resume live before switching sources"
 			break
@@ -201,17 +256,56 @@ func (s *screenState) dispatch(ctx context.Context, events chan<- any, stop <-ch
 			s.review.Notice = "No session baseline available"
 			break
 		}
+		if r == "4" && s.session == nil {
+			s.review.Notice = "Branch changes need a captured Git workspace"
+			break
+		}
 		s.review.Pinned = false
 		s.review.Scope = 0
 		s.review.ClearSelection()
 		s.review.TargetLine = 0
 		s.review.Query = ""
 		s.review.Panel = ""
-		s.review.Source = map[string]string{"1": "session", "2": "workspace", "3": "project"}[r]
+		s.review.Source = map[string]string{"1": "session", "2": "workspace", "3": "project", "4": "branch"}[r]
+		if r == "3" {
+			s.review.Inbox = false
+		}
 		s.review.FullFile = r == "3"
 		s.review.Browser, s.review.PatchFocused = true, false
 		s.updateSource()
 		s.review.Notice = ""
+	case "timeline-open":
+		if s.review.Checkpoint != nil {
+			s.review.Notice = "Checkpoint stays pinned · P: resume live before opening the timeline"
+			break
+		}
+		if len(s.review.Timeline) == 0 {
+			s.review.Notice = "No observed change batches yet"
+			break
+		}
+		index := min(max(0, s.review.TimelineIndex), len(s.review.Timeline)-1)
+		entry := s.review.Timeline[index]
+		batch := diffview.CompareTrees(s.root, entry.Before, entry.After)
+		if batch.Err != nil {
+			s.review.Notice = batch.Err.Error()
+			break
+		}
+		batch.Label = fmt.Sprintf("Observed batch %d · %s", entry.ID, entry.ObservedAt.Local().Format("15:04:05"))
+		batch.Branch = s.sessionView.Branch
+		latest := s.sessionView
+		s.review.Pinned = false
+		s.review.ClearSelection()
+		s.review.Scope, s.review.Selected, s.review.Scroll = 0, 0, 0
+		s.review.Query, s.review.Panel = "", ""
+		s.review.Source = "session"
+		s.review.Inbox = false
+		s.review.Update(batch)
+		s.review.Latest = latest
+		s.review.Pinned = true
+		s.review.PinnedVersion = batch.Version
+		s.review.Browser, s.review.PatchFocused, s.review.FullFile = true, false, false
+		s.review.SetTimeline(s.review.Timeline)
+		s.review.Notice = "Observed batch pinned · P: return to live session"
 	case "copy", "path", "feedback", "copy-context":
 		value := ""
 		if r == "copy-context" {
@@ -336,7 +430,7 @@ func (s *screenState) dispatch(ctx context.Context, events chan<- any, stop <-ch
 			s.review.Notice = "Open Workspace (2) to stage changes"
 			break
 		}
-		if s.review.Source == "session" || f.Scope == diffview.Session {
+		if s.review.Source != "workspace" && s.review.Source != "" {
 			s.review.Notice = "Press 2 for Workspace, then stage the file or hunk"
 			break
 		}

--- a/internal/diffview/branch.go
+++ b/internal/diffview/branch.go
@@ -1,0 +1,77 @@
+package diffview
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// BranchChanges compares the captured working tree with the merge base of HEAD
+// and the repository's local default branch. It includes committed and
+// uncommitted work without fetching or changing the user's repository.
+func BranchChanges(root, after string) Snapshot {
+	s := Snapshot{Root: root, Tree: after, Label: "Branch changes", UpdatedAt: time.Now()}
+	if !validOID(after) {
+		s.Err = fmt.Errorf("branch changes need a captured Git snapshot")
+		return s
+	}
+	if out, err := gitOutput(root, "symbolic-ref", "--quiet", "--short", "HEAD"); err == nil {
+		s.Branch = strings.TrimSpace(string(out))
+	} else if out, err := gitOutput(root, "rev-parse", "--short", "HEAD"); err == nil {
+		s.Branch = strings.TrimSpace(string(out)) + " (detached)"
+	}
+	baseRef, baseName, err := defaultBranch(root)
+	if err != nil {
+		s.Err = err
+		return s
+	}
+	head, err := gitOutput(root, "rev-parse", "--verify", "HEAD")
+	if err != nil {
+		s.Err = fmt.Errorf("branch changes need at least one commit")
+		return s
+	}
+	base, err := gitOutput(root, "merge-base", strings.TrimSpace(string(head)), baseRef)
+	if err != nil {
+		s.Err = fmt.Errorf("find merge base with %s: %w", baseName, err)
+		return s
+	}
+	s.Files, s.Err = collectDiff(root, BranchScope, []string{strings.TrimSpace(string(base)), after})
+	s.Label = "Branch changes from " + baseName
+	s.Finish()
+	return s
+}
+
+// BranchHead identifies commits that can change branch comparison even when the
+// captured tree is unchanged, such as committing the current working tree.
+func BranchHead(root string) string {
+	out, err := gitOutput(root, "rev-parse", "--verify", "HEAD")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func defaultBranch(root string) (ref, name string, err error) {
+	if out, e := gitOutput(root, "symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"); e == nil {
+		ref = strings.TrimSpace(string(out))
+		if ref != "" {
+			if _, verifyErr := gitOutput(root, "show-ref", "--verify", "--quiet", ref); verifyErr != nil {
+				ref = ""
+			}
+		}
+		if ref != "" {
+			return ref, strings.TrimPrefix(ref, "refs/remotes/"), nil
+		}
+	}
+	for _, candidate := range []struct{ ref, name string }{
+		{"refs/remotes/origin/main", "origin/main"},
+		{"refs/heads/main", "main"},
+		{"refs/remotes/origin/master", "origin/master"},
+		{"refs/heads/master", "master"},
+	} {
+		if _, e := gitOutput(root, "show-ref", "--verify", "--quiet", candidate.ref); e == nil {
+			return candidate.ref, candidate.name, nil
+		}
+	}
+	return "", "", fmt.Errorf("default branch not found locally (set origin/HEAD or create main/master)")
+}

--- a/internal/diffview/branch_test.go
+++ b/internal/diffview/branch_test.go
@@ -1,0 +1,79 @@
+package diffview
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBranchChangesIncludesCommittedAndWorkingTreeChanges(t *testing.T) {
+	root := t.TempDir()
+	runGit(t, root, "init", "-q", "-b", "main")
+	runGit(t, root, "config", "user.name", "Stvena Test")
+	runGit(t, root, "config", "user.email", "test@example.invalid")
+	writeFile(t, root, "base.txt", "base\n")
+	runGit(t, root, "add", ".")
+	runGit(t, root, "commit", "-qm", "base")
+	runGit(t, root, "switch", "-qc", "feature")
+	writeFile(t, root, "base.txt", "committed\n")
+	runGit(t, root, "commit", "-qam", "feature")
+	writeFile(t, root, "working.txt", "uncommitted\n")
+
+	after := captureTree(t, root)
+	s := BranchChanges(root, after)
+	if s.Err != nil {
+		t.Fatal(s.Err)
+	}
+	if s.Label != "Branch changes from main" || s.Branch != "feature" || s.FileCount != 2 {
+		t.Fatalf("branch snapshot: %+v", s)
+	}
+	if findFile(t, s, "base.txt", BranchScope).Status != "M" || findFile(t, s, "working.txt", BranchScope).Status != "A" {
+		t.Fatalf("branch files: %+v", s.Files)
+	}
+}
+
+func TestBranchChangesTracksCommitWhenTreeStaysTheSame(t *testing.T) {
+	root := t.TempDir()
+	runGit(t, root, "init", "-q", "-b", "main")
+	runGit(t, root, "config", "user.name", "Stvena Test")
+	runGit(t, root, "config", "user.email", "test@example.invalid")
+	writeFile(t, root, "file.txt", "base\n")
+	runGit(t, root, "add", ".")
+	runGit(t, root, "commit", "-qm", "base")
+	writeFile(t, root, "file.txt", "working\n")
+	tree := captureTree(t, root)
+	beforeHead := BranchHead(root)
+	if BranchChanges(root, tree).FileCount != 1 {
+		t.Fatal("dirty default branch should compare against HEAD")
+	}
+	runGit(t, root, "commit", "-qam", "working")
+	if BranchHead(root) == beforeHead || BranchChanges(root, tree).FileCount != 0 {
+		t.Fatal("commit with the same tree did not refresh branch comparison")
+	}
+}
+
+func TestBranchChangesExplainsMissingDefaultBranch(t *testing.T) {
+	root := t.TempDir()
+	runGit(t, root, "init", "-q", "-b", "topic")
+	runGit(t, root, "config", "user.name", "Stvena Test")
+	runGit(t, root, "config", "user.email", "test@example.invalid")
+	if err := os.WriteFile(filepath.Join(root, "file.txt"), []byte("one\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, root, "add", ".")
+	runGit(t, root, "commit", "-qm", "first")
+	if got := BranchChanges(root, captureTree(t, root)); got.Err == nil {
+		t.Fatalf("missing default branch was accepted: %+v", got)
+	}
+}
+
+func captureTree(t *testing.T, root string) string {
+	t.Helper()
+	runGit(t, root, "add", "-A")
+	defer runGit(t, root, "reset", "-q")
+	out, err := gitOutput(root, "write-tree")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out[:len(out)-1])
+}

--- a/internal/diffview/diff.go
+++ b/internal/diffview/diff.go
@@ -30,6 +30,7 @@ const (
 	Unstaged     Scope = "unstaged"
 	Untracked    Scope = "untracked"
 	Session      Scope = "session"
+	BranchScope  Scope = "branch"
 	ProjectScope Scope = "project"
 )
 

--- a/internal/editor/review.go
+++ b/internal/editor/review.go
@@ -1,0 +1,167 @@
+package editor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/nccapo/stvena/internal/session"
+)
+
+type ReviewFocus struct {
+	Tree    string `json:"tree"`
+	Source  string `json:"source"`
+	Path    string `json:"path"`
+	Line    int    `json:"line"`
+	EndLine int    `json:"endLine"`
+}
+
+// ReviewState is a small, source-only companion protocol. It intentionally
+// contains no patch text: the TUI remains the authoritative review surface.
+type ReviewState struct {
+	Version         int          `json:"version"`
+	Session         string       `json:"session"`
+	Sequence        uint64       `json:"sequence"`
+	Active          bool         `json:"active"`
+	UpdatedAt       time.Time    `json:"updatedAt"`
+	ChangedAt       time.Time    `json:"changedAt,omitempty"`
+	Focus           *ReviewFocus `json:"focus,omitempty"`
+	UnreviewedFiles int          `json:"unreviewedFiles"`
+	UnreviewedHunks int          `json:"unreviewedHunks"`
+	NewerBatches    int          `json:"newerBatches"`
+}
+
+type ReviewPublisher struct {
+	path, session string
+	state         ReviewState
+	writtenAt     time.Time
+}
+
+func OpenReview(saved *session.Session) (*ReviewPublisher, error) {
+	dir, err := repositoryGitDir(saved.Root)
+	if err != nil {
+		return nil, err
+	}
+	return &ReviewPublisher{path: filepath.Join(dir, "stvena-review.json"), session: saved.ID,
+		state: ReviewState{Version: 1, Session: saved.ID, Active: true}}, nil
+}
+
+func (p *ReviewPublisher) Publish(focus *ReviewFocus, files, hunks, newer int) error {
+	next := p.state
+	changed := !reflect.DeepEqual(next.Focus, focus) || next.UnreviewedFiles != files ||
+		next.UnreviewedHunks != hunks || next.NewerBatches != newer
+	if !changed && !p.writtenAt.IsZero() && time.Since(p.writtenAt) < 5*time.Second {
+		return nil
+	}
+	if focus != nil {
+		copy := *focus
+		next.Focus = &copy
+	} else {
+		next.Focus = nil
+	}
+	if changed {
+		next.Sequence++
+		next.ChangedAt = time.Now().UTC()
+	}
+	next.UnreviewedFiles, next.UnreviewedHunks, next.NewerBatches = files, hunks, newer
+	next.UpdatedAt = time.Now().UTC()
+	if err := session.AtomicJSON(p.path, next); err != nil {
+		return err
+	}
+	p.state, p.writtenAt = next, time.Now()
+	return nil
+}
+
+func (p *ReviewPublisher) Close() {
+	data, err := os.ReadFile(p.path)
+	var current ReviewState
+	if err != nil || json.Unmarshal(data, &current) != nil || current.Session != p.session {
+		return
+	}
+	p.state.Active = false
+	p.state.UpdatedAt = time.Now().UTC()
+	_ = session.AtomicJSON(p.path, p.state)
+}
+
+type Request struct {
+	Version   int       `json:"version"`
+	Session   string    `json:"session"`
+	ID        string    `json:"id"`
+	Action    string    `json:"action"`
+	Path      string    `json:"path"`
+	Line      int       `json:"line"`
+	EndLine   int       `json:"endLine"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+type RequestReader struct {
+	path, session, lastID string
+}
+
+func OpenRequests(saved *session.Session) (*RequestReader, error) {
+	dir, err := repositoryGitDir(saved.Root)
+	if err != nil {
+		return nil, err
+	}
+	reader := &RequestReader{path: filepath.Join(dir, "stvena-request.json"), session: saved.ID}
+	// A saved session can be reopened. Never replay a request left for the
+	// previous process; only descriptors replaced after this reader opens count.
+	if data, readErr := os.ReadFile(reader.path); readErr == nil {
+		var previous Request
+		if json.Unmarshal(data, &previous) == nil {
+			reader.lastID = previous.ID
+		}
+	}
+	return reader, nil
+}
+
+func (r *RequestReader) Poll() (*Request, error) {
+	data, err := os.ReadFile(r.path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > 64*1024 {
+		return nil, fmt.Errorf("editor request exceeds 64 KiB")
+	}
+	var request Request
+	if err := json.Unmarshal(data, &request); err != nil {
+		return nil, fmt.Errorf("read editor request: %w", err)
+	}
+	if request.ID == r.lastID || request.Session != r.session {
+		return nil, nil
+	}
+	r.lastID = request.ID
+	if request.Version != 1 || request.ID == "" || request.Action != "review" && request.Action != "context" ||
+		!validRequestPath(request.Path) || request.Line < 1 || request.EndLine < request.Line ||
+		request.UpdatedAt.IsZero() || time.Since(request.UpdatedAt) > time.Minute || time.Since(request.UpdatedAt) < -time.Minute {
+		return nil, fmt.Errorf("invalid or expired editor request")
+	}
+	return &request, nil
+}
+
+func validRequestPath(path string) bool {
+	if path == "" || strings.ContainsRune(path, 0) || filepath.IsAbs(path) {
+		return false
+	}
+	clean := filepath.Clean(filepath.FromSlash(path))
+	return clean != "." && clean != ".." && !strings.HasPrefix(clean, ".."+string(filepath.Separator))
+}
+
+func repositoryGitDir(root string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "git", "-C", root, "rev-parse", "--absolute-git-dir").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/editor/review_test.go
+++ b/internal/editor/review_test.go
@@ -1,0 +1,85 @@
+package editor
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nccapo/stvena/internal/session"
+)
+
+func TestReviewPublisherAndEditorRequests(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	root := t.TempDir()
+	if out, err := exec.Command("git", "-C", root, "init", "-q").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %s: %v", out, err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "file.txt"), []byte("one\ntwo\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	saved, err := session.Open(root, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer saved.Close()
+	publisher, err := OpenReview(saved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	focus := &ReviewFocus{Tree: saved.Baseline, Source: "session", Path: "file.txt", Line: 2, EndLine: 2}
+	if err := publisher.Publish(focus, 3, 4, 1); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(publisher.path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state ReviewState
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatal(err)
+	}
+	if state.Sequence != 1 || state.Focus == nil || state.Focus.Path != "file.txt" || state.UnreviewedHunks != 4 {
+		t.Fatalf("review state: %+v", state)
+	}
+	if err := publisher.Publish(focus, 3, 4, 1); err != nil || publisher.state.Sequence != 1 {
+		t.Fatalf("unchanged review advanced: %+v %v", publisher.state, err)
+	}
+
+	reader, err := OpenRequests(saved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := Request{Version: 1, Session: saved.ID, ID: "request-1", Action: "context", Path: "file.txt", Line: 1, EndLine: 2, UpdatedAt: time.Now().UTC()}
+	if err := session.AtomicJSON(reader.path, request); err != nil {
+		t.Fatal(err)
+	}
+	got, err := reader.Poll()
+	if err != nil || got == nil || got.Action != "context" || got.EndLine != 2 {
+		t.Fatalf("request: %+v %v", got, err)
+	}
+	if duplicate, err := reader.Poll(); err != nil || duplicate != nil {
+		t.Fatalf("duplicate request returned: %+v %v", duplicate, err)
+	}
+	reopenedReader, err := OpenRequests(saved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stale, err := reopenedReader.Poll(); err != nil || stale != nil {
+		t.Fatalf("request replayed after reader reopen: %+v %v", stale, err)
+	}
+	request.ID, request.Path = "request-2", "../outside"
+	if err := session.AtomicJSON(reader.path, request); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reader.Poll(); err == nil {
+		t.Fatal("unsafe editor path accepted")
+	}
+	publisher.Close()
+	data, err = os.ReadFile(publisher.path)
+	if err != nil || json.Unmarshal(data, &state) != nil || state.Active {
+		t.Fatalf("review publisher remained active: %+v %v", state, err)
+	}
+}

--- a/internal/review/actions.go
+++ b/internal/review/actions.go
@@ -20,6 +20,9 @@ var Actions = []Action{
 	{"1", "This session", "Changes observed since the agent started"},
 	{"2", "Whole workspace", "All staged, unstaged and new files"},
 	{"3", "Project files", "Browse and search every captured project file"},
+	{"4", "Branch changes", "Committed and working changes since the default-branch merge base"},
+	{"I", "Review inbox", "Show only files that still need review in the current source"},
+	{"L", "Session timeline", "Inspect stable change batches observed during this Stvena session"},
 	{"/", "Find text / file", "Search code, or filter paths in the file browser"},
 	{":", "Go to line", "Jump directly to a source line"},
 	{"s", "Side-by-side diff", "Compare old and new code"},
@@ -185,6 +188,21 @@ func (s *State) AdvancedKey(key string, visible int) bool {
 		}
 		return true
 	}
+	if s.Panel == "Timeline" {
+		switch key {
+		case "esc", "L":
+			s.Panel = ""
+		case "j", "down":
+			s.TimelineIndex = min(max(0, len(s.Timeline)-1), s.TimelineIndex+1)
+		case "k", "up":
+			s.TimelineIndex = max(0, s.TimelineIndex-1)
+		case "enter":
+			if len(s.Timeline) > 0 {
+				s.Request = "timeline-open"
+			}
+		}
+		return true
+	}
 	if s.Panel != "" {
 		switch key {
 		case "o":
@@ -244,6 +262,24 @@ func (s *State) AdvancedKey(key string, visible int) bool {
 	case "B":
 		s.Panel = "Context"
 		s.PanelScroll = 0
+	case "I":
+		if s.Source == "project" {
+			s.Notice = "Review inbox is available for change views"
+			return true
+		}
+		s.Inbox = !s.Inbox
+		s.Selected, s.Scroll, s.Horizontal = 0, 0, 0
+		s.ClearSelection()
+		s.filter("")
+		if s.Inbox {
+			files, hunks, changed := s.ReviewInboxCounts()
+			s.Notice = fmt.Sprintf("Review inbox · %d files · %d hunks · %d changed again", files, hunks, changed)
+		} else {
+			s.Notice = "Showing all changes"
+		}
+	case "L":
+		s.Panel = "Timeline"
+		s.TimelineIndex = max(0, len(s.Timeline)-1)
 	case "a":
 		s.Menu = true
 	case ":":
@@ -316,7 +352,7 @@ func (s *State) AdvancedKey(key string, visible int) bool {
 		s.Request = "fullscreen"
 	case "+", "-":
 		s.Request = key
-	case "1", "2", "3":
+	case "1", "2", "3", "4":
 		s.Request = key
 	case "S":
 		s.Request = "stage-file"
@@ -376,6 +412,9 @@ func (s *State) AdvancedKey(key string, visible int) bool {
 		delete(s.reviewed, f.Key())
 		s.Hunks[id] = !wasReviewed
 		s.Remember(*f)
+		if s.Inbox && s.Reviewed(*f) {
+			s.filter("")
+		}
 		s.Notice = "Hunk review updated"
 		s.Request = "save"
 	default:

--- a/internal/review/context_test.go
+++ b/internal/review/context_test.go
@@ -3,6 +3,7 @@ package review
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -85,5 +86,37 @@ func TestContextDraftPersistsAndProjectDoesNotEraseReviewMarks(t *testing.T) {
 	}
 	if len(saved.Attachments) != 1 || saved.ContextQuestion != "Explain this" {
 		t.Fatal("draft was not saved")
+	}
+}
+
+func TestEditorRangeUsesCapturedProjectContent(t *testing.T) {
+	root := t.TempDir()
+	if out, err := exec.Command("git", "-C", root, "init", "-q").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %s: %v", out, err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "file.go"), []byte("one\ntwo\nthree\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("git", "-C", root, "add", "file.go").CombinedOutput(); err != nil {
+		t.Fatalf("git add: %s: %v", out, err)
+	}
+	treeBytes, err := exec.Command("git", "-C", root, "write-tree").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tree := strings.TrimSpace(string(treeBytes))
+	project := diffview.Project(root, tree)
+	if err := os.WriteFile(filepath.Join(root, "file.go"), []byte("different live source\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	var s State
+	if err := s.AddCapturedRange(project, "file.go", 2, 3); err != nil {
+		t.Fatal(err)
+	}
+	if len(s.Attachments) != 1 || !strings.Contains(s.Attachments[0].Message, "two\nthree") || strings.Contains(s.Attachments[0].Message, "different live source") {
+		t.Fatalf("wrong captured editor context: %+v", s.Attachments)
+	}
+	if err := s.AddCapturedRange(project, "file.go", 3, 4); err == nil {
+		t.Fatal("out-of-range editor selection accepted")
 	}
 }

--- a/internal/review/editor.go
+++ b/internal/review/editor.go
@@ -1,0 +1,98 @@
+package review
+
+import (
+	"fmt"
+
+	"github.com/nccapo/stvena/internal/diffview"
+)
+
+// WorkingRange identifies the real working-file range represented by the
+// review cursor. Removed-only rows fall back to the nearest surviving line.
+func (s *State) WorkingRange() (path string, start, end int, ok bool) {
+	f := s.Current()
+	if f == nil || s.Browser || f.Status == "D" || (s.FullFile && s.ContentLoading) {
+		return "", 0, 0, false
+	}
+	lines := s.DisplayLines()
+	if len(lines) == 0 {
+		return "", 0, 0, false
+	}
+	a, b := s.SelectedRange()
+	for i := a; i <= b; i++ {
+		line := lines[i]
+		if (s.Selecting && !s.SelectionIncludes(i, line)) || line.New < 1 {
+			continue
+		}
+		if start == 0 || line.New < start {
+			start = line.New
+		}
+		if line.New > end {
+			end = line.New
+		}
+	}
+	if start == 0 {
+		for distance := 1; distance < len(lines); distance++ {
+			for _, i := range []int{a + distance, a - distance} {
+				if i >= 0 && i < len(lines) && lines[i].New > 0 {
+					return f.Path, lines[i].New, lines[i].New, true
+				}
+			}
+		}
+		return "", 0, 0, false
+	}
+	return f.Path, start, end, true
+}
+
+// AddCapturedRange collects an IDE selection from the immutable project tree.
+// It reuses SelectionMessage so IDE- and TUI-created context have identical
+// provenance and size limits.
+func (s *State) AddCapturedRange(snapshot diffview.Snapshot, path string, start, end int) error {
+	if snapshot.Tree == "" || snapshot.Err != nil {
+		return fmt.Errorf("wait for a captured project version before collecting editor context")
+	}
+	if start < 1 || end < start {
+		return fmt.Errorf("invalid editor selection")
+	}
+	index := -1
+	for i := range snapshot.Files {
+		if snapshot.Files[i].Path == path {
+			index = i
+			break
+		}
+	}
+	if index < 0 {
+		return fmt.Errorf("%s is not in the captured project", path)
+	}
+	f := snapshot.Files[index]
+	content := diffview.LoadContent(snapshot.Root, f)
+	if content.Err != nil {
+		return content.Err
+	}
+	if content.Binary {
+		return fmt.Errorf("binary files cannot be added as text context")
+	}
+	if end > len(content.Lines) {
+		return fmt.Errorf("editor selection is outside the captured file; wait for refresh and try again")
+	}
+	temporary := State{
+		Snapshot:       snapshot,
+		Indices:        []int{index},
+		PatchFocused:   true,
+		FullFile:       true,
+		Content:        content,
+		ContentKey:     f.Key(),
+		Selecting:      true,
+		SelectionStart: start - 1,
+		Scroll:         end - 1,
+		SelectionSide:  'n',
+	}
+	message, err := temporary.SelectionMessage()
+	if err != nil {
+		return err
+	}
+	return s.AddAttachment(Attachment{
+		Label:   fmt.Sprintf("%s:%d–%d", path, start, end),
+		Tree:    snapshot.Tree,
+		Message: message,
+	})
+}

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/nccapo/stvena/internal/attention"
@@ -18,6 +19,20 @@ type AgentSummary struct {
 	Label        string
 	State        attention.State
 	Active, Next bool
+}
+
+type TimelineEntry struct {
+	ID                        uint64
+	Before, After             string
+	ObservedAt                time.Time
+	FileCount, Added, Deleted int
+}
+
+type scrollAnchor struct {
+	line int
+	old  bool
+	text string
+	kind byte
 }
 
 type State struct {
@@ -57,6 +72,7 @@ type State struct {
 	SelectionMouse                    bool
 	SelectionSide                     byte
 	Source                            string
+	Inbox                             bool
 	ProjectRows                       []ProjectEntry
 	TreeIndex                         int
 	ExpandedFolders                   map[string]bool
@@ -75,6 +91,8 @@ type State struct {
 	Hunks                             map[string]bool
 	History                           map[string]Record
 	Comments                          []Comment
+	Timeline                          []TimelineEntry
+	TimelineIndex, NewerBatches       int
 	LastCheck, CheckTree, CheckStatus string
 	CheckLines                        []string
 	CheckRunning                      bool
@@ -93,17 +111,30 @@ func (s *State) Current() *diffview.File {
 	return &s.Snapshot.Files[s.Indices[s.Selected]]
 }
 func (s *State) Update(snapshot diffview.Snapshot) {
+	key, path, anchor := "", "", scrollAnchor{}
+	if f := s.Current(); f != nil {
+		key = f.Key()
+		path = f.Path
+		anchor = s.sourceAnchor()
+	}
 	s.Latest = snapshot
 	if s.Pinned {
 		s.observeCheckpoint(snapshot)
 		return
 	}
-	key := ""
-	if f := s.Current(); f != nil {
-		key = f.Key()
-	}
 	s.Snapshot = snapshot
 	s.filter(key)
+	if f := s.Current(); path != "" && (f == nil || f.Key() != key) {
+		for visible, index := range s.Indices {
+			if s.Snapshot.Files[index].Path == path {
+				s.Selected = visible
+				break
+			}
+		}
+	}
+	if f := s.Current(); f != nil && f.Path == path && anchor.line > 0 && !s.Browser {
+		s.restoreAnchor(anchor)
+	}
 	if s.Source == "project" {
 		return
 	}
@@ -118,8 +149,7 @@ func (s *State) Update(snapshot diffview.Snapshot) {
 		active[f.Key()] = true
 	}
 	for key := range s.reviewed {
-		isSession := strings.HasPrefix(key, string(diffview.Session)+"\x00")
-		if (s.Source == "" || isSession == (s.Source == "session")) && !active[key] {
+		if s.keyBelongsToSource(key) && !active[key] {
 			delete(s.reviewed, key)
 		}
 	}
@@ -131,11 +161,147 @@ func (s *State) Update(snapshot diffview.Snapshot) {
 		}
 	}
 	for id := range s.Hunks {
-		isSession := strings.HasPrefix(id, string(diffview.Session)+"\x00")
-		if (s.Source == "" || isSession == (s.Source == "session")) && !activeHunks[id] {
+		key := id
+		if separator := strings.LastIndexByte(id, ':'); separator >= 0 {
+			key = id[:separator]
+		}
+		if s.keyBelongsToSource(key) && !activeHunks[id] {
 			delete(s.Hunks, id)
 		}
 	}
+}
+
+func (s *State) keyBelongsToSource(key string) bool {
+	scope, _, _ := strings.Cut(key, "\x00")
+	switch s.Source {
+	case "session":
+		return scope == string(diffview.Session)
+	case "branch":
+		return scope == string(diffview.BranchScope)
+	case "project":
+		return false
+	default:
+		return scope != string(diffview.Session) && scope != string(diffview.BranchScope) && scope != string(diffview.ProjectScope)
+	}
+}
+
+func (s *State) sourceAnchor() scrollAnchor {
+	if s.Browser {
+		return scrollAnchor{}
+	}
+	lines := s.DisplayLines()
+	for distance := 0; distance < len(lines); distance++ {
+		for _, index := range []int{s.Scroll + distance, s.Scroll - distance} {
+			if index < 0 || index >= len(lines) {
+				continue
+			}
+			if lines[index].New > 0 {
+				return scrollAnchor{line: lines[index].New, text: lines[index].Text, kind: lines[index].Kind}
+			}
+			if lines[index].Old > 0 {
+				return scrollAnchor{line: lines[index].Old, old: true, text: lines[index].Text, kind: lines[index].Kind}
+			}
+		}
+	}
+	return scrollAnchor{}
+}
+
+func (s *State) restoreAnchor(anchor scrollAnchor) {
+	if s.FullFile {
+		s.Scroll = max(0, anchor.line-1)
+		s.TargetLine = anchor.line
+		return
+	}
+	lines := s.DisplayLines()
+	best, distance := -1, int(^uint(0)>>1)
+	for i, row := range lines {
+		n := row.New
+		if anchor.old {
+			n = row.Old
+		}
+		if row.Text == anchor.text && row.Kind == anchor.kind && n > 0 {
+			d := n - anchor.line
+			if d < 0 {
+				d = -d
+			}
+			if d < distance {
+				best, distance = i, d
+			}
+		}
+	}
+	if best >= 0 {
+		s.Scroll = best
+		return
+	}
+	best, distance = 0, int(^uint(0)>>1)
+	for i, row := range lines {
+		n := row.New
+		if anchor.old {
+			n = row.Old
+		}
+		if n == anchor.line {
+			s.Scroll = i
+			return
+		}
+		if n == 0 {
+			continue
+		}
+		d := n - anchor.line
+		if d < 0 {
+			d = -d
+		}
+		if d < distance {
+			best, distance = i, d
+		}
+	}
+	s.Scroll = best
+}
+
+func (s *State) SetTimeline(entries []TimelineEntry) {
+	wasNewest := len(s.Timeline) == 0 || s.TimelineIndex >= len(s.Timeline)-1
+	s.Timeline = append([]TimelineEntry(nil), entries...)
+	if wasNewest {
+		s.TimelineIndex = max(0, len(entries)-1)
+	} else {
+		s.TimelineIndex = min(s.TimelineIndex, max(0, len(entries)-1))
+	}
+	s.NewerBatches = 0
+	if s.Pinned {
+		for i, entry := range entries {
+			if entry.After == s.Snapshot.Tree {
+				s.NewerBatches = len(entries) - i - 1
+				break
+			}
+		}
+	}
+}
+
+func (s *State) ReviewInboxCounts() (files, hunks, changedAgain int) {
+	files, hunks = s.ReviewCounts(s.Snapshot)
+	for _, f := range s.Snapshot.Files {
+		if s.Reviewed(f) {
+			continue
+		}
+		if previous, ok := s.History[f.Key()]; ok && fingerprint(previous.File) != fingerprint(f) {
+			changedAgain++
+		}
+	}
+	return
+}
+
+func (s *State) ReviewCounts(snapshot diffview.Snapshot) (files, hunks int) {
+	for _, f := range snapshot.Files {
+		if s.Reviewed(f) {
+			continue
+		}
+		files++
+		for h := range HunkRanges(f.Lines) {
+			if !s.HunkReviewed(f, h) {
+				hunks++
+			}
+		}
+	}
+	return
 }
 func (s *State) filter(key string) {
 	s.Indices = nil
@@ -144,6 +310,9 @@ func (s *State) filter(key string) {
 			continue
 		}
 		if !strings.Contains(strings.ToLower(f.Path+" "+f.OldPath), strings.ToLower(s.Query)) {
+			continue
+		}
+		if s.Inbox && s.Reviewed(f) {
 			continue
 		}
 		s.Indices = append(s.Indices, i)
@@ -263,7 +432,7 @@ func (s *State) Key(key string, visible int) {
 	}
 	if s.Panel != "" && s.Prompt == "" && s.ConfirmAction == "" && !s.Menu {
 		switch key {
-		case "1", "2", "3":
+		case "1", "2", "3", "4":
 			s.Panel = ""
 			s.Request = key
 			return
@@ -280,8 +449,8 @@ func (s *State) Key(key string, visible int) {
 	}
 	if s.Source == "project" && s.Panel == "" && s.Prompt == "" {
 		switch key {
-		case "v", "s", "view-diff", "tab", " ", "H", "N", "R":
-			s.Notice = "Project files · 1: session changes · 2: workspace changes"
+		case "v", "s", "view-diff", "tab", " ", "H", "N", "R", "I":
+			s.Notice = "Project files · 1: session · 2: workspace · 4: branch changes"
 			return
 		}
 	}
@@ -351,7 +520,7 @@ func (s *State) Key(key string, visible int) {
 			s.filter("")
 		}
 	case "tab":
-		if s.Source == "session" {
+		if s.Source != "workspace" && s.Source != "" {
 			break
 		}
 		s.Scope = (s.Scope + 1) % len(Scopes)
@@ -451,6 +620,9 @@ func (s *State) Key(key string, visible int) {
 					s.Hunks[HunkID(*f, h)] = true
 				}
 				s.Remember(*f)
+			}
+			if s.Inbox {
+				s.filter("")
 			}
 		}
 	}

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -2,6 +2,7 @@ package review
 
 import (
 	"testing"
+	"time"
 
 	"github.com/nccapo/stvena/internal/diffview"
 )
@@ -12,6 +13,96 @@ func sample() diffview.Snapshot {
 		{Path: "alpha.go", Scope: diffview.Unstaged, Lines: []string{"@@ -1 +1 @@", "-after", "+again"}},
 		{Path: "目录/新.go", Scope: diffview.Untracked, Lines: []string{"@@ -0,0 +1 @@", "+new"}},
 	}}
+}
+
+func TestReviewInboxShowsNewAndChangedAgainFiles(t *testing.T) {
+	var s State
+	s.Source = "workspace"
+	s.Update(sample())
+	s.Key(" ", 10)
+	s.Key("I", 10)
+	if !s.Inbox || len(s.Indices) != 2 || s.Current().Scope != diffview.Unstaged {
+		t.Fatalf("review inbox did not hide reviewed file: %+v", s.Indices)
+	}
+	next := sample()
+	next.Files[0].Lines = []string{"@@ -1 +1 @@", "-before", "+changed again"}
+	s.Update(next)
+	files, hunks, changed := s.ReviewInboxCounts()
+	if len(s.Indices) != 3 || files != 3 || hunks != 3 || changed != 1 {
+		t.Fatalf("changed file did not re-enter inbox: indices=%v counts=%d/%d/%d", s.Indices, files, hunks, changed)
+	}
+	s.Key("I", 10)
+	if s.Inbox || len(s.Indices) != 3 {
+		t.Fatal("all-changes view was not restored")
+	}
+}
+
+func TestReviewInboxRemovesFileAfterLastHunk(t *testing.T) {
+	var s State
+	s.Source = "session"
+	s.Update(diffview.Snapshot{Files: []diffview.File{{Path: "file.go", Scope: diffview.Session, Lines: []string{"@@ -1 +1 @@", "-old", "+new"}}}})
+	s.Key("I", 10)
+	s.Browser, s.PatchFocused, s.Scroll = false, true, 1
+	s.Key("H", 10)
+	if len(s.Indices) != 0 {
+		t.Fatalf("reviewed hunk stayed in inbox: %v", s.Indices)
+	}
+	_, _, changed := s.ReviewInboxCounts()
+	if changed != 0 {
+		t.Fatal("a current hunk review was labeled changed again")
+	}
+}
+
+func TestLiveRefreshKeepsSemanticPatchAnchor(t *testing.T) {
+	before := diffview.Snapshot{Files: []diffview.File{{Path: "file.go", Scope: diffview.Unstaged, Lines: []string{
+		"@@ -10,3 +10,3 @@", " context", "-old", "+kept", " context",
+	}}}}
+	var s State
+	s.Source = "workspace"
+	s.Update(before)
+	s.Browser, s.PatchFocused, s.Scroll = false, true, 3
+	after := diffview.Snapshot{Files: []diffview.File{{Path: "file.go", Scope: diffview.Unstaged, Lines: []string{
+		"@@ -1 +1 @@", "-first", "+changed", "@@ -10,3 +11,3 @@", " context", "-old", "+kept", " context",
+	}}}}
+	s.Update(after)
+	if s.Scroll != 6 || s.DisplayLines()[s.Scroll].Text != "+kept" {
+		t.Fatalf("semantic anchor moved: scroll=%d line=%+v", s.Scroll, s.DisplayLines()[s.Scroll])
+	}
+	after.Files[0].Scope = diffview.Staged
+	s.Update(after)
+	if s.Current().Scope != diffview.Staged || s.Scroll != 6 {
+		t.Fatalf("anchor did not survive workspace scope transition: %+v", s)
+	}
+}
+
+func TestWorkingRangeFollowsSelectionAndSurvivingLines(t *testing.T) {
+	s := State{Snapshot: diffview.Snapshot{Files: []diffview.File{{Path: "file.go", Scope: diffview.Session, Lines: []string{
+		"@@ -4,2 +4,3 @@", "-removed", "+first", "+second", " context",
+	}}}}, Indices: []int{0}, PatchFocused: true, Scroll: 3, Selecting: true, SelectionStart: 2}
+	path, start, end, ok := s.WorkingRange()
+	if !ok || path != "file.go" || start != 4 || end != 5 {
+		t.Fatalf("working selection: %q %d-%d %v", path, start, end, ok)
+	}
+	s.Selecting, s.Scroll = false, 1
+	_, start, end, ok = s.WorkingRange()
+	if !ok || start != 4 || end != 4 {
+		t.Fatalf("removed line did not choose surviving neighbor: %d-%d %v", start, end, ok)
+	}
+}
+
+func TestTimelineTracksNewerBatchesWhilePinned(t *testing.T) {
+	entries := []TimelineEntry{{ID: 1, After: "one", ObservedAt: time.Now()}, {ID: 2, After: "two", ObservedAt: time.Now()}}
+	s := State{Pinned: true, Snapshot: diffview.Snapshot{Tree: "one"}}
+	s.SetTimeline(entries)
+	if s.NewerBatches != 1 || s.TimelineIndex != 1 {
+		t.Fatalf("timeline state: %+v", s)
+	}
+	s.Key("L", 10)
+	s.Key("up", 10)
+	s.Key("enter", 10)
+	if s.TimelineIndex != 0 || s.Request != "timeline-open" {
+		t.Fatalf("timeline navigation: %+v", s)
+	}
 }
 
 func TestNextUnreviewedSkipsMarksAndFindsChangedVersions(t *testing.T) {
@@ -104,6 +195,40 @@ func TestReviewInvalidatedOnlyForChangedFile(t *testing.T) {
 	s.Update(diffview.Snapshot{})
 	if len(s.reviewed) != 0 || s.Current() != nil {
 		t.Fatal("removed files retained review state")
+	}
+}
+
+func TestHunkCleanupHandlesColonInPath(t *testing.T) {
+	snapshot := diffview.Snapshot{Files: []diffview.File{{Path: "name:part.go", Scope: diffview.Session, Lines: []string{"@@ -1 +1 @@", "-old", "+new"}}}}
+	var s State
+	s.Source = "session"
+	s.Update(snapshot)
+	s.Hunks = map[string]bool{HunkID(snapshot.Files[0], 0): true}
+	s.Update(diffview.Snapshot{})
+	if len(s.Hunks) != 0 {
+		t.Fatalf("stale colon-path hunk survived cleanup: %v", s.Hunks)
+	}
+}
+
+func TestReviewMarksStayIndependentAcrossSources(t *testing.T) {
+	workspace := sample()
+	var s State
+	s.Source = "workspace"
+	s.Update(workspace)
+	s.Key(" ", 10)
+	workspaceKey := workspace.Files[0].Key()
+	branch := diffview.Snapshot{Files: []diffview.File{{Path: "alpha.go", Scope: diffview.BranchScope, Lines: []string{"@@ -1 +1 @@", "-base", "+branch"}}}}
+	s.Source = "branch"
+	s.Update(branch)
+	s.Key(" ", 10)
+	branchKey := branch.Files[0].Key()
+	if _, ok := s.reviewed[workspaceKey]; !ok {
+		t.Fatal("branch view erased workspace review")
+	}
+	s.Source = "workspace"
+	s.Update(workspace)
+	if _, ok := s.reviewed[branchKey]; !ok {
+		t.Fatal("workspace view erased branch review")
 	}
 }
 func TestHunksScrollingAndFileNavigation(t *testing.T) {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -21,10 +21,22 @@ import (
 type Session struct {
 	ID, Root, Baseline, LastTree string
 	CreatedAt                    time.Time
-	Dir                          string `json:"-"`
+	Batches                      []Batch `json:",omitempty"`
+	Dir                          string  `json:"-"`
 	index                        string
 	mu                           sync.Mutex
 }
+
+// Batch is one stable working-tree transition observed by Stvena. It does not
+// claim that a particular agent or conversation turn authored the change.
+type Batch struct {
+	ID                        uint64
+	Before, After             string
+	ObservedAt                time.Time
+	FileCount, Added, Deleted int
+}
+
+const maxBatches = 100
 
 func RepoDir(root string) (string, error) {
 	cache, err := os.UserCacheDir()
@@ -155,6 +167,49 @@ func (s *Session) Capture() (string, error) {
 }
 func (s *Session) Save() error {
 	return AtomicJSON(filepath.Join(s.Dir, s.ID+".json"), s, filepath.Join(s.Dir, "latest.json"))
+}
+
+// RecordBatch retains a bounded, replayable history of successfully compared
+// captured trees. The newest tree remains protected by the session latest ref;
+// individual refs keep intermediate snapshots available for timeline review.
+func (s *Session) RecordBatch(before, after string, observedAt time.Time, files, added, deleted int) error {
+	if before == "" || after == "" || before == after {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.Batches) > 0 && s.Batches[len(s.Batches)-1].After == after {
+		return nil
+	}
+	id := uint64(1)
+	if len(s.Batches) > 0 {
+		id = s.Batches[len(s.Batches)-1].ID + 1
+	}
+	ref := s.ref(fmt.Sprintf("batches/%06d", id))
+	if _, err := git(s.Root, nil, "update-ref", ref, after); err != nil {
+		return err
+	}
+	previous := append([]Batch(nil), s.Batches...)
+	s.Batches = append(s.Batches, Batch{ID: id, Before: before, After: after, ObservedAt: observedAt.UTC(), FileCount: files, Added: added, Deleted: deleted})
+	var dropped []Batch
+	if len(s.Batches) > maxBatches {
+		dropped = append(dropped, s.Batches[:len(s.Batches)-maxBatches]...)
+		s.Batches = append([]Batch(nil), s.Batches[len(s.Batches)-maxBatches:]...)
+		if _, err := git(s.Root, nil, "update-ref", s.ref("batch-base"), s.Batches[0].Before); err != nil {
+			s.Batches = previous
+			_, _ = git(s.Root, nil, "update-ref", "-d", ref)
+			return err
+		}
+	}
+	if err := s.Save(); err != nil {
+		s.Batches = previous
+		_, _ = git(s.Root, nil, "update-ref", "-d", ref)
+		return err
+	}
+	for _, batch := range dropped {
+		_, _ = git(s.Root, nil, "update-ref", "-d", s.ref(fmt.Sprintf("batches/%06d", batch.ID)))
+	}
+	return nil
 }
 func (s *Session) Close() { _ = os.Remove(s.index); _ = os.Remove(s.index + ".lock") }
 

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -172,3 +172,44 @@ func TestCapturePreservesRacyIndexTimestamp(t *testing.T) {
 		t.Fatal("capture changed the real index timestamp")
 	}
 }
+
+func TestObservedBatchesPersistAndRetainIntermediateTrees(t *testing.T) {
+	root := t.TempDir()
+	git(t, root, "init")
+	write(t, root, "file.txt", "zero\n")
+	git(t, root, "add", ".")
+	git(t, root, "commit", "-m", "initial")
+	s, err := session.Open(root, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	before := s.LastTree
+	write(t, root, "file.txt", "one\n")
+	after, err := s.Capture()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stamp := time.Now().Add(-time.Minute).UTC()
+	if err := s.RecordBatch(before, after, stamp, 1, 1, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RecordBatch(before, after, stamp, 1, 1, 1); err != nil {
+		t.Fatal(err)
+	}
+	if len(s.Batches) != 1 || s.Batches[0].ID != 1 || !s.Batches[0].ObservedAt.Equal(stamp) {
+		t.Fatalf("recorded batches: %+v", s.Batches)
+	}
+	ref := "refs/stvena/sessions/" + s.ID + "/batches/000001"
+	if git(t, root, "rev-parse", ref) != after {
+		t.Fatal("batch tree was not retained")
+	}
+	reopened, err := session.Open(root, true, s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	if len(reopened.Batches) != 1 || reopened.Batches[0].After != after {
+		t.Fatalf("reopened batches: %+v", reopened.Batches)
+	}
+}

--- a/internal/ui/overlays.go
+++ b/internal/ui/overlays.go
@@ -150,12 +150,27 @@ func renderOverlay(s *review.State, width, height int) []string {
 				content = append(content, safeText(line))
 			}
 		}
+	case s.Panel == "Timeline":
+		title = fmt.Sprintf("Session timeline · %d observed batches", len(s.Timeline))
+		footer = " ↑/↓: select · Enter: open batch · Esc: back"
+		start, count := PanelListWindow(s.TimelineIndex, len(s.Timeline), height)
+		for i := start; i < start+count; i++ {
+			batch := s.Timeline[i]
+			style, marker := "", "  "
+			if i == s.TimelineIndex {
+				style, marker = focusedBG+bold, "› "
+			}
+			content = append(content, style+marker+fmt.Sprintf("%s  Batch %d  %d files  +%d -%d", batch.ObservedAt.Local().Format("15:04:05"), batch.ID, batch.FileCount, batch.Added, batch.Deleted)+reset)
+		}
+		if len(s.Timeline) == 0 {
+			content = []string{"No change batches observed yet.", "Batches appear after a stable captured tree changes."}
+		}
 	}
 	var rows []string
 	add := func(t string) { rows = append(rows, reviewRow(t, width)) }
 	add(headerBG + bold + " " + title)
 	start := 0
-	if s.Panel != "" && s.Panel != "Context" && s.Panel != "Problems" {
+	if s.Panel != "" && s.Panel != "Context" && s.Panel != "Problems" && s.Panel != "Timeline" {
 		start = min(s.PanelScroll, max(0, len(content)-max(1, height-2)))
 		s.PanelScroll = start
 	}

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -281,8 +281,8 @@ var FooterControls = []FooterControl{
 	{"Ctrl-G", "focus", "Switch panes"}, {"Ctrl-]", "new-agent", "New agent"},
 	{"Ctrl-N", "next-agent", "Next agent"}, {"Ctrl-P", "previous-agent", "Previous agent"},
 	{"Ctrl-W", "close-agent", "Close agent"}, {"Ctrl-Y", "next-attention", "Next attention"},
-	{"1", "1", "Changes"}, {"2", "2", "Workspace"}, {"3", "3", "Files"},
-	{"B", "B", "Context"}, {"b", "b", "Paste to agent"}, {"T", "T", "Checks"},
+	{"1", "1", "Changes"}, {"2", "2", "Workspace"}, {"3", "3", "Files"}, {"4", "4", "Branch"},
+	{"B", "B", "Context"}, {"b", "b", "Paste to agent"}, {"T", "T", "Checks"}, {"L", "L", "Timeline"},
 	{"K", "K", "Checkpoint"}, {"a", "a", "Actions"}, {"F", "F", "Expand"},
 	{"?", "?", "Configuration"}, {"Ctrl-Q", "quit-app", "Quit all"}, {"F6", "footer", "Bottom panel"},
 }

--- a/internal/ui/render_test.go
+++ b/internal/ui/render_test.go
@@ -150,7 +150,7 @@ func TestFullFileAndBrowserRender(t *testing.T) {
 func TestAdvancedViewsAndControlsFit(t *testing.T) {
 	f := diffview.File{Path: "file.go", Scope: diffview.Session, Lines: []string{"@@ -1 +1 @@", "-func oldName() { return 100 }", "+func newName() { return 200 }"}}
 	for _, width := range []int{20, 60, 120} {
-		for _, mode := range []string{"split", "wrap", "menu", "comments", "prompt", "confirm", "context", "preview", "problems"} {
+		for _, mode := range []string{"split", "wrap", "menu", "comments", "prompt", "confirm", "context", "preview", "problems", "timeline"} {
 			var s review.State
 			s.Update(diffview.Snapshot{Files: []diffview.File{f}})
 			s.PatchFocused = true
@@ -176,6 +176,9 @@ func TestAdvancedViewsAndControlsFit(t *testing.T) {
 			case "problems":
 				s.Panel = "Problems"
 				s.Problems = []checks.Problem{{Path: "src/界.go", Line: 12, Message: "expected value"}}
+			case "timeline":
+				s.Panel = "Timeline"
+				s.Timeline = []review.TimelineEntry{{ID: 1, FileCount: 2, Added: 3, Deleted: 1}}
 			case "confirm":
 				s.ConfirmAction = "stage-file"
 				s.ConfirmDetail = "Stage file.go?"
@@ -197,5 +200,18 @@ func TestAdvancedViewsAndControlsFit(t *testing.T) {
 	layout := NewLayoutOptions(120, 30, 40, true)
 	if layout.LeftWidth != 0 || layout.DiffWidth != 120 {
 		t.Fatal("full review did not expand")
+	}
+}
+
+func TestReviewInboxClearState(t *testing.T) {
+	f := diffview.File{Path: "file.go", Scope: diffview.Session, Status: "M", Lines: []string{"@@ -1 +1 @@", "-old", "+new"}}
+	var s review.State
+	s.Source = "session"
+	s.Update(diffview.Snapshot{Files: []diffview.File{f}, FileCount: 1})
+	s.Key(" ", 10)
+	s.Key("I", 10)
+	text := ansi.Strip(strings.Join(renderReview(&s, 60, 15, true), "\n"))
+	if !strings.Contains(text, "Review inbox is clear") {
+		t.Fatalf("missing inbox empty state: %s", text)
 	}
 }

--- a/internal/ui/review.go
+++ b/internal/ui/review.go
@@ -73,15 +73,24 @@ func renderReview(s *review.State, width, height int, focused bool) []string {
 		if pinnedVersion == "" {
 			pinnedVersion = s.Snapshot.Version
 		}
-		if s.Latest.Version != pinnedVersion {
+		if s.NewerBatches > 0 {
+			source += fmt.Sprintf(" (%d newer batches)", s.NewerBatches)
+		} else if s.Latest.Version != pinnedVersion {
 			source += " (updates available)"
 		}
 	}
 	if !s.Pinned {
 		source += " · Live"
 	}
-	if s.Source != "session" && s.Source != "project" {
+	if s.Source == "workspace" || s.Source == "" {
 		source += " · " + scope
+	}
+	if s.Inbox {
+		files, hunks, changed := s.ReviewInboxCounts()
+		source += fmt.Sprintf(" · Inbox %df/%dh", files, hunks)
+		if changed > 0 {
+			source += fmt.Sprintf(" · %d changed again", changed)
+		}
 	}
 	if s.Checkpoint != nil {
 		freshness := "live unchanged"
@@ -174,7 +183,10 @@ func renderReview(s *review.State, width, height int, focused bool) []string {
 			add(line)
 		}
 	} else if s.Snapshot.Err == nil && len(s.Indices) == 0 {
-		if s.Snapshot.FileCount == 0 {
+		if s.Inbox && s.Query == "" && s.Scope == 0 {
+			add(dim + " Review inbox is clear.")
+			add(muted + " Press I to show all changes.")
+		} else if s.Snapshot.FileCount == 0 {
 			if s.Source == "session" {
 				add(dim + " No changes in this session yet.")
 				add(muted + " Existing edits are in Workspace (2).")

--- a/internal/ui/review_controls.go
+++ b/internal/ui/review_controls.go
@@ -39,7 +39,11 @@ func baseReviewControls(s *review.State) []reviewControl {
 		return []reviewControl{{"enter", label}, {"left", "←: Parent"}, {"/", "/: Find file"}}
 	}
 	if s.Browser {
-		return []reviewControl{{"enter", "Enter: open"}, {"/", "/: find file"}, {"N", "N: next unreviewed"}}
+		inbox := "I: Inbox"
+		if s.Inbox {
+			inbox = "I: All changes"
+		}
+		return []reviewControl{{"enter", "Enter: open"}, {"/", "/: find file"}, {"N", "N: next unreviewed"}, {"I", inbox}}
 	}
 	if s.Selecting {
 		return []reviewControl{{"x", "x: Collect"}, {"b", "b: Add to agent"}, {"y", "y: Copy"}, {"V", "V: Clear"}, {"P", "P: Resume live"}}
@@ -51,7 +55,11 @@ func baseReviewControls(s *review.State) []reviewControl {
 	if f := s.Current(); f != nil && s.Reviewed(*f) {
 		mark = "Space: Unmark"
 	}
-	return []reviewControl{{" ", mark}, {"N", "N: Next unreviewed"}, {"e", "e: Open editor"}}
+	inbox := "I: Inbox"
+	if s.Inbox {
+		inbox = "I: All changes"
+	}
+	return []reviewControl{{" ", mark}, {"N", "N: Next unreviewed"}, {"I", inbox}, {"e", "e: Open editor"}}
 }
 
 func reviewControlBar(s *review.State) string {
@@ -165,6 +173,8 @@ func basePanelControls(s *review.State) []reviewControl {
 		return []reviewControl{{"enter", "Enter: Source"}, {"x", "x: Collect failure"}, {"t", "t: Rerun"}, {"esc", "Esc: Logs"}}
 	case "Checks":
 		return []reviewControl{{"o", "o: Problems"}, {"t", "t: Run / rerun"}, {"esc", "Esc: Back"}}
+	case "Timeline":
+		return []reviewControl{{"enter", "Enter: Open batch"}, {"esc", "Esc: Back"}}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- add branch changes as a fourth review source
- add a review inbox and a bounded session batch timeline
- preserve live viewport position while surfacing newer batches
- add bidirectional Stvena Live review/context handoff without opening native IDE diffs
- bump the VS Code extension to 0.2.2 and document the workflow

## Testing

- go test ./...
- go test -race ./...
- go vet ./...
- go build ./...
- gofmt -l cmd internal
- npm test in extensions/vscode
- npm run package in extensions/vscode
- isolated VS Code 1.137 extension-host test: edits, reads, TUI review, editor requests, ranges, pause/resume, expiry, unsaved buffers, and no native diff tabs
- git diff --check
- gitleaks dir . --redact --no-banner